### PR TITLE
feat: RequestParser 객체 구현

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -12,9 +12,13 @@ SRCS := $(wildcard *.cpp)
 DIRS := utils \
 		GlobalConfig \
 		ConfigParser \
+		RequestMessage \
+		RequestParser \
 		ServerManager \
 		Demultiplexer \
-		TimeoutHandler
+#		TimeoutHandler \# RequestParser 테스트를 위해 임시로 주석처리
+
+
 SUBS := $(addsuffix .a,$(DIRS))
 
 include $(TOPDIR)/include_make/Variable.mk

--- a/src/RequestMessage/RequestMessage.cpp
+++ b/src/RequestMessage/RequestMessage.cpp
@@ -2,20 +2,12 @@
 #include "utils.hpp"
 #include <stdexcept>
 
-RequestMessage::RequestMessage() : method_(INIT), status_(REQ_INIT) {}
+RequestMessage::RequestMessage() : method_(NONE), status_(REQ_INIT) {}
 RequestMessage::RequestMessage(TypeMethod method, std::string targetURI) : method_(method), targetURI_(targetURI) {}
 RequestMessage::~RequestMessage() {}
 
-bool RequestMessage::hasMethod() const {
-	if (this->method_ == INIT)
-		return false;
-	return true;
-}
-
 TypeMethod RequestMessage::getMethod() const {
-	if (hasMethod())
-		return this->method_;
-	throw std::exception();//doesn't have a method yet
+	return this->method_;
 }
 
 std::string RequestMessage::getTargetURI() const {
@@ -30,11 +22,11 @@ std::string RequestMessage::getBody() const {
 	return this->body_;
 }
 
-void RequestMessage::setMethod(TypeMethod method) {
+void RequestMessage::setMethod(const TypeMethod &method) {
 	this->method_ = method;
 }
 
-void RequestMessage::setTargetURI(std::string targetURI) {
+void RequestMessage::setTargetURI(const std::string &targetURI) {
 	this->targetURI_ = targetURI;
 }
 
@@ -66,15 +58,15 @@ ssize_t RequestMessage::getMetaContentLength() const {
 	return this->metaContentLength_;
 }
 
-void RequestMessage::setStatus(TypeReqStatus status) {
+void RequestMessage::setStatus(const TypeReqStatus &status) {
 	this->status_ = status;
 }
 
-void RequestMessage::setMetaHost(std::string value) {
+void RequestMessage::setMetaHost(const std::string &value) {
 	this->metaHost_ = value;
 }
 
-void RequestMessage::setMetaConnection(std::string value) {
+void RequestMessage::setMetaConnection(const std::string &value) {
 	if (value == "keep-alive")
 		this->metaConnection_ = KEEP_ALIVE;
 	if (value == "close")
@@ -82,7 +74,7 @@ void RequestMessage::setMetaConnection(std::string value) {
 	throw std::logic_error("Error: connection value");
 }
 
-void RequestMessage::setMetaContentLength(std::string value) {
+void RequestMessage::setMetaContentLength(const std::string &value) {
 	this->metaContentLength_ = utils::stosizet(value);
 }
 

--- a/src/RequestMessage/RequestMessage.cpp
+++ b/src/RequestMessage/RequestMessage.cpp
@@ -1,7 +1,7 @@
 #include "RequestMessage.hpp"
 #include <stdexcept>
 
-RequestMessage::RequestMessage() : method_(INIT) {}
+RequestMessage::RequestMessage() : method_(INIT), status_(REQ_INIT) {}
 RequestMessage::RequestMessage(TypeMethod method, std::string targetURI) : method_(method), targetURI_(targetURI) {}
 RequestMessage::~RequestMessage() {}
 
@@ -11,7 +11,7 @@ bool RequestMessage::hasMethod() const {
 	return true;
 }
 
-TypeMethod RequestMessage::getMethod() const {
+RequestMessage::TypeMethod RequestMessage::getMethod() const {
 	if (hasMethod())
 		return this->method_;
 	throw std::exception();//doesn't have a method yet
@@ -21,14 +21,13 @@ std::string RequestMessage::getTargetURI() const {
 	return this->targetURI_;
 }
 
-TypeField RequestMessage::getFields() const {
+RequestMessage::TypeField RequestMessage::getFields() const {
 	return this->fieldLines_;
 }
 
 std::string RequestMessage::getBody() const {
 	return this->body_;
 }
-
 
 void RequestMessage::setMethod(TypeMethod method) {
 	this->method_ = method;
@@ -50,18 +49,84 @@ void RequestMessage::addBody(std::string bodyData) {
 	this->body_.append(bodyData);
 }
 
+RequestMessage::TypeReqStatus RequestMessage::getStatus() const {
+	return this->status_;
+}
+
+std:: string RequestMessage::getMetaHost() const {
+	return this->metaHost_;
+}
+
+ssize_t RequestMessage::getMetaConnection() const {
+	return this->metaConnection_;
+}
+
+ssize_t RequestMessage::getMetaContentLength() const {
+	return this->metaContentLength_;
+}
+
+void RequestMessage::setStatus(TypeReqStatus status) {
+	this->status_ = status;
+}
+
+void RequestMessage::setMetaHost(std::string value) {
+	this->metaHost_ = value;
+}
+
+void RequestMessage::setMetaConnection(ssize_t value) {
+	this->metaConnection_ = value;
+}
+
+void RequestMessage::setMetaContentLength(ssize_t value) {
+	this->metaContentLength_ = value;
+}
+
+
+
 // Parser 구현 후, 파싱 테스트용 함수, C++98 X
 #include <iostream>
 #include <iterator>
+void RequestMessage::printResult() const {
+	std::cout << "\033[32;7m PrintStartLine :\033[0m"<<std::endl;
+
+	std::cout <<"\033[37;2mmethod: \033[0m";
+	if (this->method_ == GET)
+		std::cout <<"GET;"<<std::endl;
+	else if (this->method_ == POST)
+		std::cout <<"POST;"<<std::endl;
+	else if (this->method_ == DELETE)
+		std::cout <<"DELETE;"<<std::endl;
+	else if (this->method_ == INIT)
+		std::cout <<"INIT;"<<std::endl;
+	else
+		std::cout <<"(none);"<<std::endl;
+	std::cout <<"\033[37;2muri: \033[0m";
+	std::cout <<this->targetURI_<<";"<<std::endl;
+	this->printFields();
+	this->printBody();
+}
 void RequestMessage::printFields(void) const {
-	std::cout << "\033[32;7m< PrintFields :\033[0m"<<std::endl;
+	std::cout << "\033[32;7m PrintFields :\033[0m"<<std::endl;
 	for (auto it : this->fieldLines_) {
-		std::cout <<"["<<it.first<<"]: ";
+		int cnt = 0;
+		std::cout <<it.first<<": {";
 		for (auto itt : it.second) {
-			std::cout <<"{"<<itt<<"}";
-			std::cout <<", ";
+			if (cnt != 0)
+			std::cout << ", ";
+			std::cout << itt;
+			cnt++;
 		}
-		std::cout << std::endl;
+		std::cout <<"};"<<std::endl;
 	}
-	std::cout << "\033[32;7m>\033[0m"<<std::endl;
+}
+void RequestMessage::printBody(void) const {
+	std::cout << "\033[32;7m PrintBody :\033[0m"<<std::endl;
+	for (auto it = this->body_.begin(); it != this->body_.end(); ++it) {
+        if (*it == '\n')
+            std::cout << "\\n" << std::endl;
+        else if (*it == '\r')
+            std::cout << "\\r";
+        else
+            std::cout << *it;
+	}
 }

--- a/src/RequestMessage/RequestMessage.hpp
+++ b/src/RequestMessage/RequestMessage.hpp
@@ -6,37 +6,70 @@
 
 #define CRLF "\r\n"
 enum Method { INIT, GET, POST, DELETE };
+////////////////buffersize를 굉장히 작게도 해봐야겠다
+//해당 요소까지 완성되었음을 알림
+enum requestStatus {
+	REQ_INIT,				// 생성됨
+	REQ_TOP_CRLF,			// CRLF 1개 허용됨
+	REQ_METHOD,				// 완료 => 완료이전에 판단중에 iss.peek() == EOF라면 기다려봐야함
+	REQ_TARGET_URI,			// 완료
+	REQ_STARTLINE,			// start-line 완료
+	REQ_STARTLINE_CRLF,		// start-line 이후 종료 상태 -> DONE으로 통합할지 고민
+	REQ_HEADER_FIELD_ING,	// 
+	REQ_HEADER_FIELD,		// 
+	REQ_HEADER_CRLF,		// 
+	REQ_BODY_ING,			// 
+	REQ_BODY,				// 
+	REQ_DONE,				// 
+	REQ_ERROR				// 
+};
 
 class RequestMessage {
 	public:
-		typedef enum Method 									TypeMethod;
-		typedef std::map<std::string, std::vector<std::string>>	TypeField;
+		typedef enum Method 										TypeMethod;
+		typedef enum requestStatus									TypeReqStatus;
+		typedef std::map<std::string, std::vector<std::string> >	TypeField;
 
 		RequestMessage();
 		RequestMessage(TypeMethod method, std::string target);
 		~RequestMessage();
 
-		bool		hasMethod() const;
+		bool			hasMethod() const;
 		
-		TypeMethod	getMethod() const;
-		std::string	getTargetURI() const;
-		TypeField	getFields() const;
-		std::string	getBody() const;
-		void		setMethod(TypeMethod method);
-		void		setTargetURI(std::string targetURI);
-		void		addFields(std::string field, std::vector<std::string> values);
-		void		addBody(std::string bodyData);
+		TypeMethod		getMethod() const;
+		std::string		getTargetURI() const;
+		TypeField		getFields() const;
+		std::string		getBody() const;
+		void			setMethod(TypeMethod method);
+		void			setTargetURI(std::string targetURI);
+		void			addFields(std::string field, std::vector<std::string> values);
+		void			addBody(std::string bodyData);
+		
+		TypeReqStatus	getStatus() const;
+		std:: string	getMetaHost() const;
+		ssize_t			getMetaConnection() const;
+		ssize_t			getMetaContentLength() const;
+		void			setStatus(TypeReqStatus status);
+		void			setMetaHost(std::string value);
+		void			setMetaConnection(ssize_t value);
+		void			setMetaContentLength(ssize_t value);
 
+		void printResult() const;//////////////////////////
+		void printFields() const;//////////////////////////
+		void printBody() const;//////////////////////////
 	private:
-		//should I record CRLF?
-		TypeMethod	method_;
-		std::string	targetURI_;
-		TypeField	fieldLines_;
-		std::string	body_;
+		//0,1 -> 1개까지 허용
+		TypeMethod		method_;
+		std::string		targetURI_;
+		//O -> 종료
+		TypeField		fieldLines_;
+		//O -> 종료 or body
+		std::string		body_;
 
-		//message data
-		ssize_t		contentLength;
-		//...
-
-		void	printFields(void) const;
+		//meta data
+		TypeReqStatus	status_;
+		std::string		metaHost_;
+		ssize_t			metaConnection_;
+		ssize_t			metaContentLength_;
+		//...2
 };

--- a/src/RequestMessage/RequestMessage.hpp
+++ b/src/RequestMessage/RequestMessage.hpp
@@ -4,12 +4,12 @@
 #include <map>
 #include <vector>
 
-typedef enum Method { INIT, GET, POST, DELETE } TypeMethod;
+typedef enum Method { NONE, GET, POST, DELETE } TypeMethod;
 typedef enum connection { KEEP_ALIVE, CLOSE } TypeConnection;
 typedef enum requestStatus {
 	REQ_INIT,
 	REQ_TOP_CRLF,		// CRLF(0,1)
-	REQ_METHOD,			// 완료(1) => 완료이전에 판단중에 iss.peek() == EOF라면 기다려봐야함
+	REQ_METHOD,			// 완료(1)
 	REQ_TARGET_URI,		// 완료(1)
 	REQ_STARTLINE,		// start-line 완료
 	REQ_HEADER_FIELD,	// 진행중(N)
@@ -27,14 +27,12 @@ class RequestMessage {
 		RequestMessage(TypeMethod method, std::string target);
 		~RequestMessage();
 
-		bool			hasMethod() const;
-		
 		TypeMethod		getMethod() const;
 		std::string		getTargetURI() const;
 		TypeField		getFields() const;
 		std::string		getBody() const;
-		void			setMethod(TypeMethod method);
-		void			setTargetURI(std::string targetURI);
+		void			setMethod(const TypeMethod &method);
+		void			setTargetURI(const std::string &targetURI);
 		void			addFields(std::string field, std::vector<std::string> values);
 		void			addBody(std::string bodyData);
 		
@@ -42,10 +40,10 @@ class RequestMessage {
 		std:: string	getMetaHost() const;
 		TypeConnection	getMetaConnection() const;
 		ssize_t			getMetaContentLength() const;
-		void			setStatus(TypeReqStatus status);
-		void			setMetaHost(std::string value);
-		void			setMetaConnection(std::string value);
-		void			setMetaContentLength(std::string value);
+		void			setStatus(const TypeReqStatus &status);
+		void			setMetaHost(const std::string &value);
+		void			setMetaConnection(const std::string &value);
+		void			setMetaContentLength(const std::string &value);
 
 		// 파싱 후, 결과 출력을 위한 함수
 		void printResult() const;
@@ -53,7 +51,7 @@ class RequestMessage {
 		void printBody() const;
 		void printMetaData(void) const;
 		
-		// exception class 만드는게 유용할지도..
+		// MUST TO DO: exception class 만드는게 유용할지도..
 
 	private:
 		TypeMethod		method_;
@@ -61,10 +59,9 @@ class RequestMessage {
 		TypeField		fieldLines_;
 		std::string		body_;
 
-		//meta data
+		// Header Field에 작성되어있던 메타데이터
 		TypeReqStatus	status_;
 		std::string		metaHost_;
 		TypeConnection	metaConnection_;
 		ssize_t			metaContentLength_;
-		//...2
 };

--- a/src/RequestMessage/RequestMessage.hpp
+++ b/src/RequestMessage/RequestMessage.hpp
@@ -4,30 +4,23 @@
 #include <map>
 #include <vector>
 
-#define CRLF "\r\n"
-enum Method { INIT, GET, POST, DELETE };
-////////////////buffersize를 굉장히 작게도 해봐야겠다
-//해당 요소까지 완성되었음을 알림
-enum requestStatus {
-	REQ_INIT,				// 생성됨
-	REQ_TOP_CRLF,			// CRLF 1개 허용됨
-	REQ_METHOD,				// 완료 => 완료이전에 판단중에 iss.peek() == EOF라면 기다려봐야함
-	REQ_TARGET_URI,			// 완료
-	REQ_STARTLINE,			// start-line 완료
-	REQ_STARTLINE_CRLF,		// start-line 이후 종료 상태 -> DONE으로 통합할지 고민
-	REQ_HEADER_FIELD_ING,	// 
-	REQ_HEADER_FIELD,		// 
-	REQ_HEADER_CRLF,		// 
-	REQ_BODY_ING,			// 
-	REQ_BODY,				// 
-	REQ_DONE,				// 
-	REQ_ERROR				// 
-};
+typedef enum Method { INIT, GET, POST, DELETE } TypeMethod;
+typedef enum connection { KEEP_ALIVE, CLOSE } TypeConnection;
+typedef enum requestStatus {
+	REQ_INIT,
+	REQ_TOP_CRLF,		// CRLF(0,1)
+	REQ_METHOD,			// 완료(1) => 완료이전에 판단중에 iss.peek() == EOF라면 기다려봐야함
+	REQ_TARGET_URI,		// 완료(1)
+	REQ_STARTLINE,		// start-line 완료
+	REQ_HEADER_FIELD,	// 진행중(N)
+	REQ_HEADER_CRLF,	// header-field 완료
+	REQ_BODY,			// 진행중(N)
+	REQ_DONE,
+	REQ_ERROR
+} TypeReqStatus;
 
 class RequestMessage {
 	public:
-		typedef enum Method 										TypeMethod;
-		typedef enum requestStatus									TypeReqStatus;
 		typedef std::map<std::string, std::vector<std::string> >	TypeField;
 
 		RequestMessage();
@@ -47,29 +40,31 @@ class RequestMessage {
 		
 		TypeReqStatus	getStatus() const;
 		std:: string	getMetaHost() const;
-		ssize_t			getMetaConnection() const;
+		TypeConnection	getMetaConnection() const;
 		ssize_t			getMetaContentLength() const;
 		void			setStatus(TypeReqStatus status);
 		void			setMetaHost(std::string value);
-		void			setMetaConnection(ssize_t value);
-		void			setMetaContentLength(ssize_t value);
+		void			setMetaConnection(std::string value);
+		void			setMetaContentLength(std::string value);
 
-		void printResult() const;//////////////////////////
-		void printFields() const;//////////////////////////
-		void printBody() const;//////////////////////////
+		// 파싱 후, 결과 출력을 위한 함수
+		void printResult() const;
+		void printFields() const;
+		void printBody() const;
+		void printMetaData(void) const;
+		
+		// exception class 만드는게 유용할지도..
+
 	private:
-		//0,1 -> 1개까지 허용
 		TypeMethod		method_;
 		std::string		targetURI_;
-		//O -> 종료
 		TypeField		fieldLines_;
-		//O -> 종료 or body
 		std::string		body_;
 
 		//meta data
 		TypeReqStatus	status_;
 		std::string		metaHost_;
-		ssize_t			metaConnection_;
+		TypeConnection	metaConnection_;
 		ssize_t			metaContentLength_;
 		//...2
 };

--- a/src/RequestParser/Makefile
+++ b/src/RequestParser/Makefile
@@ -1,0 +1,14 @@
+ifndef TOPDIR
+	TOPDIR = $(abspath ../../)
+endif
+ifndef SRCDIR
+	SRCDIR = $(abspath ../)
+endif
+
+NAME := RequestParser.a
+HEAD := RequestParser.hpp
+SRCS := $(wildcard *.cpp)
+
+include $(TOPDIR)/include_make/Variable.mk
+include $(TOPDIR)/include_make/Link.mk
+include $(TOPDIR)/include_make/Recipe_subsrc.mk

--- a/src/RequestParser/RequestParser.cpp
+++ b/src/RequestParser/RequestParser.cpp
@@ -1,0 +1,120 @@
+#include <iostream>
+
+#include "RequestParser.hpp"
+#include "utils.hpp"
+#include <stdexcept>
+#include <sstream>
+
+RequestParser::RequestParser() : oneLineMaxLength_(ONELINE_MAX_LENGTH), uriMaxLength_(URI_MAX_LENGTH) {}
+//RequestParser::RequestParser(size_t configBodyLength) {}
+RequestParser::~RequestParser() {}
+
+std::string RequestParser::parse(const std::string &readData, RequestMessage &reqMsg) {
+	std::istringstream iss(readData);
+	std::string buffer;
+
+	//if (reqMsg.getStatus() == REQ_BODY)
+		//body는 content length만큼 그대로 읽어들임 
+	while (std::getline(iss, buffer, '\n')) {
+		//TypeReqStatus curStatus = reqMsg.getStatus();//왜 타입 안되는거지
+		RequestMessage::TypeReqStatus curStatus = reqMsg.getStatus();
+		std::cout << "current status:"<<curStatus<<"\n";
+		if (!buffer.empty() && buffer[buffer.size() - 1] == '\r') {
+			if (buffer.size() == 1) {
+				reqMsg.setStatus(this->setStatusCRLF(curStatus));
+				curStatus = reqMsg.getStatus();
+			}
+
+			//request message의 완성도에 따라 
+			//각 helper함수를 호출하면 될 것 같다
+			buffer.erase(buffer.size() - 1);
+			if (curStatus == REQ_INIT
+			||  curStatus == REQ_TOP_CRLF)
+				this->parseStartLine(buffer, reqMsg);
+			if (curStatus == REQ_STARTLINE
+			||  curStatus == REQ_HEADER_FIELD_ING)
+				this->parseFieldLine(buffer, reqMsg);
+			if (curStatus == REQ_HEADER_CRLF)
+				this->parseBody(buffer, reqMsg);
+			if (iss.peek() == EOF)// - [ ] 덜 읽어들인 케이스
+				return buffer;// == remain data
+			
+		} else {
+			throw std::logic_error("Error: single \\n error");
+		}
+		//////////정상종료시에 connenction & content length 디폴트값설정 해주자!
+	}
+	return NULL;
+}
+
+//void RequestParser::setConfigBodyLength(size_t length) {
+//	this->bodyMaxLength = length;
+//}
+
+RequestMessage::TypeReqStatus RequestParser::setStatusCRLF(const RequestMessage::TypeReqStatus &curStatus) {
+	if (curStatus == REQ_INIT)
+		return REQ_TOP_CRLF;
+	if (curStatus == REQ_STARTLINE)
+		return REQ_STARTLINE_CRLF;
+	if (curStatus == REQ_HEADER_FIELD_ING)
+		return REQ_HEADER_CRLF;
+	//??? done상태가..???
+	return REQ_ERROR;
+}
+
+void RequestParser::parseStartLine(const std::string &line, RequestMessage &reqMsg) {
+	std::istringstream iss(line);
+	std::string buffer;
+
+	if (std::getline(iss, buffer, ' ')) {
+		if (buffer == "GET")
+			reqMsg.setMethod(GET);
+		else if (buffer == "POST")
+			reqMsg.setMethod(POST);
+		else if (buffer == "DELETE")
+			reqMsg.setMethod(DELETE);
+		else {
+			reqMsg.setStatus(REQ_ERROR);
+			throw std::logic_error("not allow method");
+		}
+	}
+	if (std::getline(iss, buffer, ' '))
+		reqMsg.setTargetURI(buffer);
+	iss >> buffer;
+	if (buffer == "HTTP/1.1")
+		reqMsg.setStatus(REQ_STARTLINE);
+	else {
+		reqMsg.setStatus(REQ_ERROR);
+		throw std::logic_error("http version error");
+	}
+}
+
+void RequestParser::parseFieldLine(const std::string &line, RequestMessage &reqMsg) {
+	std::istringstream iss(line);
+	std::string name;
+	std::string value;
+
+	std::getline(iss, name, ':');
+	iss.get();//trim 임시
+	iss >> value;
+
+	std::vector<std::string> values(1, value);//temp
+	reqMsg.addFields(name, values);
+
+	if (name == "Content-Length")
+		reqMsg.setMetaContentLength(utils::stoi(value));//int는... 안될 것 같은데..
+
+	reqMsg.setStatus(REQ_HEADER_FIELD_ING);
+}
+
+void RequestParser::parseBody(const std::string &line, RequestMessage &reqMsg) {
+	//if (reqMsg.getMetaContentLength())
+	reqMsg.addBody(line);
+	std::cout <<  "BODYBIDY:" << line << std::endl; 
+	//reqMsg.setStatus(REQ_BODY_ING);
+	reqMsg.setStatus(REQ_DONE);
+}
+
+//void RequestParser::cleanUpChunkedBody() {
+
+//}

--- a/src/RequestParser/RequestParser.cpp
+++ b/src/RequestParser/RequestParser.cpp
@@ -9,57 +9,67 @@ RequestParser::RequestParser() : oneLineMaxLength_(ONELINE_MAX_LENGTH), uriMaxLe
 //RequestParser::RequestParser(size_t configBodyLength) {}
 RequestParser::~RequestParser() {}
 
+//void RequestParser::setConfigBodyLength(size_t length) {
+//	this->bodyMaxLength = length;
+//}
+
 std::string RequestParser::parse(const std::string &readData, RequestMessage &reqMsg) {
 	std::istringstream iss(readData);
 	std::string buffer;
+	TypeReqStatus newStatus;
 
-	//if (reqMsg.getStatus() == REQ_BODY)
-		//body는 content length만큼 그대로 읽어들임 
+	// 다시 마저 읽어오는 경우도 생각해봐야함
 	while (std::getline(iss, buffer, '\n')) {
-		//TypeReqStatus curStatus = reqMsg.getStatus();//왜 타입 안되는거지
-		RequestMessage::TypeReqStatus curStatus = reqMsg.getStatus();
-		std::cout << "current status:"<<curStatus<<"\n";
+		//std::cout << "WHILE: " << buffer <<std::endl;
 		if (!buffer.empty() && buffer[buffer.size() - 1] == '\r') {
 			if (buffer.size() == 1) {
-				reqMsg.setStatus(this->setStatusCRLF(curStatus));
-				curStatus = reqMsg.getStatus();
+				newStatus = this->setStatusCRLF(reqMsg.getStatus());
+				reqMsg.setStatus(newStatus);
+				if (newStatus == REQ_HEADER_CRLF)
+					break ;// == body
+				if (newStatus == REQ_ERROR)
+					throw std::logic_error("Error: invalid CLRF location error");
+				continue ;
 			}
-
-			//request message의 완성도에 따라 
-			//각 helper함수를 호출하면 될 것 같다
-			buffer.erase(buffer.size() - 1);
-			if (curStatus == REQ_INIT
-			||  curStatus == REQ_TOP_CRLF)
-				this->parseStartLine(buffer, reqMsg);
-			if (curStatus == REQ_STARTLINE
-			||  curStatus == REQ_HEADER_FIELD_ING)
-				this->parseFieldLine(buffer, reqMsg);
-			if (curStatus == REQ_HEADER_CRLF)
-				this->parseBody(buffer, reqMsg);
+			this->handleOneLine(buffer.erase(buffer.size() - 1), reqMsg);
 			if (iss.peek() == EOF)// - [ ] 덜 읽어들인 케이스
 				return buffer;// == remain data
-			
 		} else {
 			throw std::logic_error("Error: single \\n error");
 		}
 		//////////정상종료시에 connenction & content length 디폴트값설정 해주자!
 	}
-	return NULL;
+	iss >> buffer;
+	this->parseBody(buffer, reqMsg);//body는 content length만큼 그대로 읽어들임 
+	return "";
 }
 
-//void RequestParser::setConfigBodyLength(size_t length) {
-//	this->bodyMaxLength = length;
-//}
 
-RequestMessage::TypeReqStatus RequestParser::setStatusCRLF(const RequestMessage::TypeReqStatus &curStatus) {
+void RequestParser::handleOneLine(const std::string &line, RequestMessage &reqMsg) {
+	const TypeReqStatus curStatus = reqMsg.getStatus();
+			//request message의 완성도에 따라 
+			//각 helper함수를 호출하면 될 것 같다
+	if (curStatus == REQ_INIT
+	||  curStatus == REQ_TOP_CRLF)
+		this->parseStartLine(line, reqMsg);
+	if (curStatus == REQ_STARTLINE
+	||  curStatus == REQ_HEADER_FIELD)
+		this->parseFieldLine(line, reqMsg);
+	//if (reqMsg.getStatus() == REQ_HEADER_CRLF) {
+	//	this->parseBody(line, reqMsg);//body는 content length만큼 그대로 읽어들임 
+	//	//////////////////////////////
+	//	break ;//body는 CRLF를 그대로 담아야하기때문에 다르게 처리되어야함
+	//}
+}
+
+TypeReqStatus RequestParser::setStatusCRLF(const TypeReqStatus &curStatus) {
+	// 유효한 것으로 처리되는 두 위치의 CRLF외에는 전부 에러
 	if (curStatus == REQ_INIT)
 		return REQ_TOP_CRLF;
-	if (curStatus == REQ_STARTLINE)
-		return REQ_STARTLINE_CRLF;
-	if (curStatus == REQ_HEADER_FIELD_ING)
+	if (curStatus == REQ_HEADER_FIELD)
 		return REQ_HEADER_CRLF;
-	//??? done상태가..???
 	return REQ_ERROR;
+	//??? done상태가..???
 }
 
 void RequestParser::parseStartLine(const std::string &line, RequestMessage &reqMsg) {
@@ -101,18 +111,26 @@ void RequestParser::parseFieldLine(const std::string &line, RequestMessage &reqM
 	std::vector<std::string> values(1, value);//temp
 	reqMsg.addFields(name, values);
 
-	if (name == "Content-Length")
-		reqMsg.setMetaContentLength(utils::stoi(value));//int는... 안될 것 같은데..
+	try {
+		if (name == "Host")
+			reqMsg.setMetaHost(value);
+		if (name == "Content-Length")
+			reqMsg.setMetaContentLength(value);//int는... 안될 것 같은데..
+		if (name == "Connection")
+			reqMsg.setMetaConnection(value);
+	} catch (const std::exception &e) {
+		//it is header field value error
+		//how to save this... 
+	}
 
-	reqMsg.setStatus(REQ_HEADER_FIELD_ING);
+	reqMsg.setStatus(REQ_HEADER_FIELD);
 }
 
 void RequestParser::parseBody(const std::string &line, RequestMessage &reqMsg) {
 	//if (reqMsg.getMetaContentLength())
 	reqMsg.addBody(line);
-	std::cout <<  "BODYBIDY:" << line << std::endl; 
 	//reqMsg.setStatus(REQ_BODY_ING);
-	reqMsg.setStatus(REQ_DONE);
+	reqMsg.setStatus(REQ_DONE);//우선은 종료 처리... 여기서 마음대로 종료하면 안됨!
 }
 
 //void RequestParser::cleanUpChunkedBody() {

--- a/src/RequestParser/RequestParser.hpp
+++ b/src/RequestParser/RequestParser.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "RequestMessage.hpp"
+
+#define ONELINE_MAX_LENGTH	8190//8KB - 2bytes(\r\n)
+#define URI_MAX_LENGTH		2048//2KB
+
+class RequestParser {
+	public:
+		RequestParser();
+		~RequestParser();
+
+		std::string			parse(const std::string &readData, RequestMessage &reqMsg);
+		//void				setBodyMaxLength(ssize_t length);
+
+	private:
+		ssize_t				oneLineMaxLength_;
+		ssize_t				uriMaxLength_;
+		//Optional<ssize_t>	bodyMaxLength_;//Client마다 바뀌는 설정 값
+		
+		enum requestStatus	setStatusCRLF(const enum requestStatus &curStatus);
+		void				parseStartLine(const std::string &line, RequestMessage &reqMsg);
+		void				parseFieldLine(const std::string &line, RequestMessage &reqMsg);
+		void				parseBody(const std::string &line, RequestMessage &reqMsg);
+		//void				cleanUpChunkedBody(const std::string &line);
+};
+

--- a/src/RequestParser/RequestParser.hpp
+++ b/src/RequestParser/RequestParser.hpp
@@ -10,18 +10,19 @@ class RequestParser {
 		RequestParser();
 		~RequestParser();
 
-		std::string			parse(const std::string &readData, RequestMessage &reqMsg);
-		//void				setBodyMaxLength(ssize_t length);
+		std::string		parse(const std::string &readData, RequestMessage &reqMsg);
+		//void			setBodyMaxLength(ssize_t length);
 
 	private:
-		ssize_t				oneLineMaxLength_;
-		ssize_t				uriMaxLength_;
+		ssize_t			oneLineMaxLength_;
+		ssize_t			uriMaxLength_;
 		//Optional<ssize_t>	bodyMaxLength_;//Client마다 바뀌는 설정 값
 		
-		enum requestStatus	setStatusCRLF(const enum requestStatus &curStatus);
-		void				parseStartLine(const std::string &line, RequestMessage &reqMsg);
-		void				parseFieldLine(const std::string &line, RequestMessage &reqMsg);
-		void				parseBody(const std::string &line, RequestMessage &reqMsg);
+		void			handleOneLine(const std::string &line, RequestMessage &reqMsg);
+		TypeReqStatus	setStatusCRLF(const TypeReqStatus &curStatus);
+		void			parseStartLine(const std::string &line, RequestMessage &reqMsg);
+		void			parseFieldLine(const std::string &line, RequestMessage &reqMsg);
+		void			parseBody(const std::string &line, RequestMessage &reqMsg);
 		//void				cleanUpChunkedBody(const std::string &line);
 };
 

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -1,7 +1,7 @@
 #include "utils.hpp"
 
 namespace utils {
-    // 문자열을 int로 변환하는 함수
+	// 문자열을 int로 변환하는 함수
 	int stoi(const std::string& str) {
 		char* end; // 숫자열의 끝을 가리킬 포인터
 		errno = 0; // 호출 전에 errno를 초기화
@@ -18,5 +18,23 @@ namespace utils {
 
 		// 변환 성공
 		return static_cast<int>(result);
+	}
+
+	// 문자열을 size_t로 변환하는 함수
+	size_t stosizet(const std::string& str) {
+		char* end;
+		errno = 0;
+		unsigned long result = std::strtoul(str.c_str(), &end, 10);
+
+		// 오버플로우 처리
+		if (errno == ERANGE || result > std::numeric_limits<size_t>::max()) {
+			throw std::overflow_error("size_t overflow");
+		}
+		// 유효하지 않은 포맷 처리
+		if (end == str.c_str() || *end != '\0') {
+			throw std::invalid_argument("Invalid size_t format");
+		}
+
+		return static_cast<size_t>(result);
 	}
 }

--- a/src/utils/utils.hpp
+++ b/src/utils/utils.hpp
@@ -10,6 +10,8 @@ namespace utils {
 
 	// 문자열을 int로 변환하는 함수
 	int stoi(const std::string& str);
+	// 문자열을 size_t로 변환하는 함수
+	size_t stosizet(const std::string& str);
 
 	// 입력 반복자 [first, last) 범위 내의 모든 요소가
 	// 주어진 조건(pred)을 만족하는지 확인하는 템플릿 함수


### PR DESCRIPTION
## 1. RequestParser 구현

## 2. RequestParser외 수정사항
- `src/utils`에 string to size_t기능의 함수 추가
- RequestMessage 객체 수정
    - enum requestStatus 추가
    - 메타 데이터 추가(: header-field 중 주요한 데이터)
    - message 출력함수 추가