### PR TITLE
feat: findRequestConfig() 구현

### DIFF
--- a/src/ConfigParser/ConfigParser.cpp
+++ b/src/ConfigParser/ConfigParser.cpp
@@ -25,17 +25,22 @@ void ConfigParser::parse(GlobalConfig& globalConfig, const char* path) {
 		}
 	}
 
+	// server 블록이 없으면 예외 발생
+    if (globalConfig.servers_.empty()) {
+        throw std::runtime_error("No server blocks found in config file");
+    }
+
 	// 각 location 블록에 대해 server의 request handling을 적용
 	for (std::vector<ServerConfig>::iterator server = globalConfig.servers_.begin(); server != globalConfig.servers_.end(); ++server) {
 		for (std::vector<LocationConfig>::iterator location = server->locations_.begin(); location != server->locations_.end(); ++location) {
-			getEffectiveReqHandling(server->reqHandling_, location->reqHandling_);
+			getEffectiveReqHandling(server->reqConfig_, location->reqConfig_);
 		}
 	}
 	// 각 request handling에 대해 기본값을 설정
 	for (std::vector<ServerConfig>::iterator server = globalConfig.servers_.begin(); server != globalConfig.servers_.end(); ++server) {
-		setDefaultReqHandling(server->reqHandling_);
+		setDefaultReqHandling(server->reqConfig_);
 		for (std::vector<LocationConfig>::iterator location = server->locations_.begin(); location != server->locations_.end(); ++location) {
-			setDefaultReqHandling(location->reqHandling_);
+			setDefaultReqHandling(location->reqConfig_);
 		}
 	}
 }
@@ -74,7 +79,7 @@ void ConfigParser::parseServerBlock(std::ifstream& configFile, ServerConfig& ser
 		}
 		else {
 			// 그 외의 경우 request handling 관련 설정을 파싱함
-			parseReqHandleConf(configFile, serverBlock.reqHandling_, token);
+			parseRequestConfig(configFile, serverBlock.reqConfig_, token);
 		}
 
 		// 각 지시문이 끝난 후 ';'가 있어야 함
@@ -109,10 +114,10 @@ void ConfigParser::parseLocationBlock(std::ifstream& configFile, LocationConfig&
 		}
 
 		if (token == "methods") {
-			parseMethods(configFile, locationBlock.reqHandling_.methods_);
+			parseMethods(configFile, locationBlock.reqConfig_.methods_);
 		} else {
 			// request handling 관련 설정을 파싱함
-			parseReqHandleConf(configFile, locationBlock.reqHandling_, token);
+			parseRequestConfig(configFile, locationBlock.reqConfig_, token);
 		}
 
 		// 각 지시문이 끝난 후 ';'가 있어야 함
@@ -124,23 +129,23 @@ void ConfigParser::parseLocationBlock(std::ifstream& configFile, LocationConfig&
 }
 
 // request handling 설정을 파싱하는 함수
-void ConfigParser::parseReqHandleConf(std::ifstream& configFile, ReqHandleConf& reqHandling, const std::string& token) {
+void ConfigParser::parseRequestConfig(std::ifstream& configFile, RequestConfig& reqConfig, const std::string& token) {
 	if (token == "error_page") {
-		parseErrorPage(configFile, reqHandling.errorPages_);
+		parseErrorPage(configFile, reqConfig.errorPages_);
 	} else if (token == "return") {
-		parseReturn(configFile, reqHandling.returnUrl_, reqHandling.returnStatus_);
+		parseReturn(configFile, reqConfig.returnUrl_, reqConfig.returnStatus_);
 	} else if (token == "root") {
-		parseRoot(configFile, reqHandling.root_);
+		parseRoot(configFile, reqConfig.root_);
 	} else if (token == "index") {
-		parseIndexFile(configFile, reqHandling.indexFile_);
+		parseIndexFile(configFile, reqConfig.indexFile_);
 	} else if (token == "upload_path") {
-		parseUploadPath(configFile, reqHandling.uploadPath_);
+		parseUploadPath(configFile, reqConfig.uploadPath_);
 	} else if (token == "cgi_extension") {
-		parseCgiExtension(configFile, reqHandling.cgiExtension_);
+		parseCgiExtension(configFile, reqConfig.cgiExtension_);
 	} else if (token == "client_max_body_size") {
-		parseClientMaxBodySize(configFile, reqHandling.clientMaxBodySize_);
+		parseClientMaxBodySize(configFile, reqConfig.clientMaxBodySize_);
 	} else if (token == "autoindex") {
-		parseAutoIndex(configFile, reqHandling.autoIndex_);
+		parseAutoIndex(configFile, reqConfig.autoIndex_);
 	} else {
 		// 예상하지 못한 토큰이면 예외 발생
 		throw std::runtime_error("Unexpected token: " + token);
@@ -148,7 +153,7 @@ void ConfigParser::parseReqHandleConf(std::ifstream& configFile, ReqHandleConf& 
 }
 
 // 서버 설정의 request handling을 location 설정에 적용하는 함수
-void ConfigParser::getEffectiveReqHandling(const ReqHandleConf& serverReqHandling, ReqHandleConf& locationReqHandling) {
+void ConfigParser::getEffectiveReqHandling(const RequestConfig& serverReqHandling, RequestConfig& locationReqHandling) {
 	if (locationReqHandling.methods_.empty()) {
 		locationReqHandling.methods_ = serverReqHandling.methods_;
 	}
@@ -182,23 +187,23 @@ void ConfigParser::getEffectiveReqHandling(const ReqHandleConf& serverReqHandlin
 }
 
 // request handling에 기본값을 설정하는 함수
-void ConfigParser::setDefaultReqHandling(ReqHandleConf& reqHandling) {
-	if (reqHandling.methods_.empty()) {
+void ConfigParser::setDefaultReqHandling(RequestConfig& reqConfig) {
+	if (reqConfig.methods_.empty()) {
 		// 기본 메서드는 GET, POST, DELETE
-		reqHandling.methods_.push_back("GET");
-		reqHandling.methods_.push_back("POST");
-		reqHandling.methods_.push_back("DELETE");
+		reqConfig.methods_.push_back("GET");
+		reqConfig.methods_.push_back("POST");
+		reqConfig.methods_.push_back("DELETE");
 	}
-	if (reqHandling.indexFile_.empty()) {
+	if (reqConfig.indexFile_.empty()) {
 		// 기본 인덱스 파일은 "index.html"
-		reqHandling.indexFile_ = "index.html";
+		reqConfig.indexFile_ = "index.html";
 	}
-	if (!reqHandling.clientMaxBodySize_.isSet()) {
+	if (!reqConfig.clientMaxBodySize_.isSet()) {
 		// 기본 최대 본문 크기는 1MB
-		reqHandling.clientMaxBodySize_ = 1048576;  // 1MB
+		reqConfig.clientMaxBodySize_ = 1048576;  // 1MB
 	}
-	if (!reqHandling.autoIndex_.isSet()) {
+	if (!reqConfig.autoIndex_.isSet()) {
 		// 기본 autoindex 값은 false
-		reqHandling.autoIndex_ = false;
+		reqConfig.autoIndex_ = false;
 	}
 }

--- a/src/ConfigParser/ConfigParser.hpp
+++ b/src/ConfigParser/ConfigParser.hpp
@@ -19,13 +19,13 @@ public:
 private:
 	static void	parseServerBlock(std::ifstream& configFile, ServerConfig& serverBlock);
 	static void	parseLocationBlock(std::ifstream& configFile, LocationConfig& locationBlock);
-	static void	parseReqHandleConf(std::ifstream& configFile, ReqHandleConf& reqHandling, const std::string& token);
+	static void	parseRequestConfig(std::ifstream& configFile, RequestConfig& reqConfig, const std::string& token);
 
 	// LocationBlock이 ServerBlock의 값을 상속받은 후 오버라이드
-	static void	getEffectiveReqHandling(const ReqHandleConf& serverReqHandling, \
-										ReqHandleConf& locationReqHandling);
+	static void	getEffectiveReqHandling(const RequestConfig& serverReqHandling, \
+										RequestConfig& locationReqHandling);
 	// 설정값이 없을 경우 기본값으로 초기화
-	static void	setDefaultReqHandling(ReqHandleConf& ReqHandling);
+	static void	setDefaultReqHandling(RequestConfig& ReqHandling);
 
 	// ServerBlock 파서
 	static void	parseHostPort(std::ifstream& configFile, std::string& host, unsigned int& port);
@@ -35,7 +35,7 @@ private:
 	static void	parsePath(std::ifstream& configFile, std::string& path);
 	static void	parseMethods(std::ifstream& configFile, std::vector<std::string>& methods);
 
-	// ReqHandleConf 파서
+	// RequestConfig 파서
 	static void	parseErrorPage(std::ifstream& configFile, std::map<int, std::string>& errorPages);
 	static void	parseReturn(std::ifstream& configFile, std::string& returnUrl, int& returnStatus);
 	static void	parseRoot(std::ifstream& configFile, std::string& root);

--- a/src/ConfigParser/parse_simple_directives.cpp
+++ b/src/ConfigParser/parse_simple_directives.cpp
@@ -1,6 +1,6 @@
 #include "ConfigParser.hpp"
 
-// ReqHandleConf 파서를 위한 함수들
+// RequestConfig 파서를 위한 함수들
 
 // error_page 지시문을 파싱하는 함수
 void ConfigParser::parseErrorPage(std::ifstream& configFile, std::map<int, std::string> &errorPages) {

--- a/src/GlobalConfig/GlobalConfig.cpp
+++ b/src/GlobalConfig/GlobalConfig.cpp
@@ -5,6 +5,63 @@
 #include <string>
 #include <map>
 
+// GlobalConfig 클래스 내의 findRequestConfig 함수: 
+// listenFd, 도메인 이름, 그리고 target URL에 해당하는 RequestConfig를 찾는다.
+const RequestConfig* GlobalConfig::findRequestConfig(const int listenFd, const std::string& domainName, \
+const std::string& targetUrl) const {
+	// listenFd가 등록된 서버 목록에 없다면 NULL 반환
+	if (listenFdToServers_.find(listenFd) == listenFdToServers_.end())
+		return NULL;
+	// listenFd에 해당하는 서버들의 벡터를 가져옴
+	const std::vector<ServerConfig*>& servers = listenFdToServers_.at(listenFd);
+	// 주어진 도메인 이름과 일치하는 서버 구성을 찾음
+	const ServerConfig& server = findServerConfig(servers, domainName);
+	// 해당 서버에서 target URL에 해당하는 location 설정을 찾음
+	return findLocationConfig(server, targetUrl);
+}
+
+
+// GlobalConfig 클래스 내의 findServerConfig 함수: 
+// 주어진 서버 목록에서 도메인 이름과 일치하는 서버 설정을 찾는다.
+const ServerConfig& GlobalConfig::findServerConfig(const std::vector<ServerConfig*>& servers, \
+const std::string& domainName) const {
+	// 서버 목록을 순회하며 각 서버의 serverNames_ 벡터 내에서 도메인 이름을 찾음
+	for (size_t i = 0; i < servers.size(); ++i) {
+		for (size_t j = 0; j < servers[i]->serverNames_.size(); j++) {
+			// 도메인 이름이 일치하면 해당 서버 설정을 반환
+			if (servers[i]->serverNames_[j] == domainName)
+				return *servers[i];
+		}
+	}
+	// 일치하는 도메인을 찾지 못하면 첫 번째 서버 설정을 반환
+	return *servers[0];
+}
+
+
+// GlobalConfig 클래스 내의 findLocationConfig 함수: 
+// 주어진 서버 설정 내에서 target URL과 가장 잘 맞는 location 설정을 찾는다.
+const RequestConfig* GlobalConfig::findLocationConfig(const ServerConfig& server, \
+const std::string& targetUrl) const {
+	const LocationConfig* longestPrefixMatch = NULL; // 가장 긴 접두어 매칭을 저장할 포인터 초기화
+	// 서버의 location 설정 목록을 순회
+	for (size_t i = 0; i < server.locations_.size(); ++i) {
+		// targetUrl이 현재 location의 path_로 시작하는지 확인
+		if (targetUrl.find(server.locations_[i].path_) == 0) {
+			// 현재 매칭이 이전보다 길거나 아직 매칭이 없으면 업데이트
+			if (longestPrefixMatch == NULL || \
+				server.locations_[i].path_.size() > longestPrefixMatch->path_.size())
+				longestPrefixMatch = &server.locations_[i];
+		}
+	}
+	// 적절한 location 설정을 찾지 못하면 기본 RequestConfig를 반환
+	if (longestPrefixMatch == NULL) {
+		return &server.reqConfig_;
+	} else {
+		// 가장 긴 접두어 매칭을 가진 location의 RequestConfig를 반환
+		return &longestPrefixMatch->reqConfig_;
+	}
+}
+
 void GlobalConfig::print() {
 	for (size_t i = 0; i < servers_.size(); i++) {
 		std::cout << "Server " << i + 1 << ":\n";
@@ -21,27 +78,27 @@ void GlobalConfig::print() {
 		std::cout << "  Request Handling:\n";
 
 		std::cout << "    Error Pages:\n";
-		for (std::map<int, std::string>::iterator it = servers_[i].reqHandling_.errorPages_.begin();
-			 it != servers_[i].reqHandling_.errorPages_.end(); ++it) {
+		for (std::map<int, std::string>::iterator it = servers_[i].reqConfig_.errorPages_.begin();
+			 it != servers_[i].reqConfig_.errorPages_.end(); ++it) {
 			std::cout << "      " << it->first << " -> " << it->second << "\n";
 		}
-		std::cout << "    Return URL: " << servers_[i].reqHandling_.returnUrl_ << "\n";
-		std::cout << "    Return Status: " << servers_[i].reqHandling_.returnStatus_ << "\n";
-		std::cout << "    Root: " << servers_[i].reqHandling_.root_ << "\n";
-		std::cout << "    Index File: " << servers_[i].reqHandling_.indexFile_ << "\n";
-		std::cout << "    Upload Path: " << servers_[i].reqHandling_.uploadPath_ << "\n";
-		std::cout << "    CGI Extension: " << servers_[i].reqHandling_.cgiExtension_ << "\n";
+		std::cout << "    Return URL: " << servers_[i].reqConfig_.returnUrl_ << "\n";
+		std::cout << "    Return Status: " << servers_[i].reqConfig_.returnStatus_ << "\n";
+		std::cout << "    Root: " << servers_[i].reqConfig_.root_ << "\n";
+		std::cout << "    Index File: " << servers_[i].reqConfig_.indexFile_ << "\n";
+		std::cout << "    Upload Path: " << servers_[i].reqConfig_.uploadPath_ << "\n";
+		std::cout << "    CGI Extension: " << servers_[i].reqConfig_.cgiExtension_ << "\n";
 
 		std::cout << "    Client Max Body Size: ";
-		if (servers_[i].reqHandling_.clientMaxBodySize_.isSet())
-			std::cout << servers_[i].reqHandling_.clientMaxBodySize_.value();
+		if (servers_[i].reqConfig_.clientMaxBodySize_.isSet())
+			std::cout << servers_[i].reqConfig_.clientMaxBodySize_.value();
 		else
 			std::cout << "N/A";
 		std::cout << "\n";
 
 		std::cout << "    Auto Index: ";
-		if (servers_[i].reqHandling_.autoIndex_.isSet())
-			std::cout << (servers_[i].reqHandling_.autoIndex_.value() ? "on" : "off");
+		if (servers_[i].reqConfig_.autoIndex_.isSet())
+			std::cout << (servers_[i].reqConfig_.autoIndex_.value() ? "on" : "off");
 		else
 			std::cout << "on";
 		std::cout << "\n";
@@ -53,35 +110,35 @@ void GlobalConfig::print() {
 				std::cout << "      Path: " << servers_[i].locations_[j].path_ << "\n";
 				std::cout << "      Request Handling:\n";
 				std::cout << "        Methods: ";
-				for (size_t k = 0; k < servers_[i].locations_[j].reqHandling_.methods_.size(); k++) {
-					std::cout << servers_[i].locations_[j].reqHandling_.methods_[k];
-					if (k < servers_[i].locations_[j].reqHandling_.methods_.size() - 1)
+				for (size_t k = 0; k < servers_[i].locations_[j].reqConfig_.methods_.size(); k++) {
+					std::cout << servers_[i].locations_[j].reqConfig_.methods_[k];
+					if (k < servers_[i].locations_[j].reqConfig_.methods_.size() - 1)
 						std::cout << ", ";
 				}
 				std::cout << "\n";
 
 				std::cout << "        Error Pages:\n";
-				for (std::map<int, std::string>::iterator it = servers_[i].locations_[j].reqHandling_.errorPages_.begin();
-					 it != servers_[i].locations_[j].reqHandling_.errorPages_.end(); ++it) {
+				for (std::map<int, std::string>::iterator it = servers_[i].locations_[j].reqConfig_.errorPages_.begin();
+					 it != servers_[i].locations_[j].reqConfig_.errorPages_.end(); ++it) {
 					std::cout << "          " << it->first << " -> " << it->second << "\n";
 				}
-				std::cout << "        Return URL: " << servers_[i].locations_[j].reqHandling_.returnUrl_ << "\n";
-				std::cout << "        Return Status: " << servers_[i].locations_[j].reqHandling_.returnStatus_ << "\n";
-				std::cout << "        Root: " << servers_[i].locations_[j].reqHandling_.root_ << "\n";
-				std::cout << "        Index File: " << servers_[i].locations_[j].reqHandling_.indexFile_ << "\n";
-				std::cout << "        Upload Path: " << servers_[i].locations_[j].reqHandling_.uploadPath_ << "\n";
-				std::cout << "        CGI Extension: " << servers_[i].locations_[j].reqHandling_.cgiExtension_ << "\n";
+				std::cout << "        Return URL: " << servers_[i].locations_[j].reqConfig_.returnUrl_ << "\n";
+				std::cout << "        Return Status: " << servers_[i].locations_[j].reqConfig_.returnStatus_ << "\n";
+				std::cout << "        Root: " << servers_[i].locations_[j].reqConfig_.root_ << "\n";
+				std::cout << "        Index File: " << servers_[i].locations_[j].reqConfig_.indexFile_ << "\n";
+				std::cout << "        Upload Path: " << servers_[i].locations_[j].reqConfig_.uploadPath_ << "\n";
+				std::cout << "        CGI Extension: " << servers_[i].locations_[j].reqConfig_.cgiExtension_ << "\n";
 
 				std::cout << "        Client Max Body Size: ";
-				if (servers_[i].locations_[j].reqHandling_.clientMaxBodySize_.isSet())
-					std::cout << servers_[i].locations_[j].reqHandling_.clientMaxBodySize_.value();
+				if (servers_[i].locations_[j].reqConfig_.clientMaxBodySize_.isSet())
+					std::cout << servers_[i].locations_[j].reqConfig_.clientMaxBodySize_.value();
 				else
 					std::cout << "N/A";
 				std::cout << "\n";
 
 				std::cout << "        Auto Index: ";
-				if (servers_[i].locations_[j].reqHandling_.autoIndex_.isSet())
-					std::cout << (servers_[i].locations_[j].reqHandling_.autoIndex_.value() ? "on" : "off");
+				if (servers_[i].locations_[j].reqConfig_.autoIndex_.isSet())
+					std::cout << (servers_[i].locations_[j].reqConfig_.autoIndex_.value() ? "on" : "off");
 				else
 					std::cout << "on";
 				std::cout << "\n";

--- a/src/GlobalConfig/GlobalConfig.hpp
+++ b/src/GlobalConfig/GlobalConfig.hpp
@@ -5,49 +5,62 @@
 # include <vector>
 # include <map>
 
-// ReqHandleConf는 요청 처리를 위한 설정을 나타냅니다.
-class ReqHandleConf {
+// RequestConfig는 요청 처리를 위한 설정을 나타냅니다.
+class RequestConfig {
 public:
-	std::vector<std::string>	methods_;         // 예: GET, POST 등
-	std::map<int, std::string>	errorPages_;     // 오류 코드와 오류 페이지 매핑
-	std::string					returnUrl_;      // 반환 또는 리디렉션할 URL
-	int							returnStatus_;   // 리디렉션/반환을 위한 HTTP 상태 코드
-	std::string					root_;           // 요청의 루트 디렉토리
-	std::string					indexFile_;      // 기본 제공 파일 (예: index.html)
-	std::string					uploadPath_;     // 업로드된 파일을 저장할 경로
-	std::string					cgiExtension_;   // CGI 스크립트를 식별하는 확장자
-	Optional<size_t>			clientMaxBodySize_; // 요청의 최대 허용 본문 크기
-	Optional<bool>				autoIndex_;      // 디렉토리 자동 색인화 여부
+	RequestConfig() : returnStatus_(0) {}			// 기본 생성자는 멤버를 기본값으로 초기화합니다.
 
-	// 기본 생성자는 멤버를 기본값으로 초기화합니다.
-	ReqHandleConf()
-	: returnStatus_(0)
-	{}
+	std::vector<std::string>	methods_;			// 예: GET, POST 등
+	std::map<int, std::string>	errorPages_;		// 오류 코드와 오류 페이지 매핑
+	std::string					returnUrl_;			// 반환 또는 리디렉션할 URL
+	int							returnStatus_;		// 리디렉션/반환을 위한 HTTP 상태 코드
+	std::string					root_;				// 요청의 루트 디렉토리
+	std::string					indexFile_;			// 기본 제공 파일 (예: index.html)
+	std::string					uploadPath_;		// 업로드된 파일을 저장할 경로
+	std::string					cgiExtension_;		// CGI 스크립트를 식별하는 확장자
+	Optional<size_t>			clientMaxBodySize_;	// 요청의 최대 허용 본문 크기
+	Optional<bool>				autoIndex_;			// 디렉토리 자동 색인화 여부
 };
 
 // LocationConfig는 특정 위치 블록의 구성을 나타냅니다.
 class LocationConfig {
 public:
-	std::string					path_;           // 위치 경로 (예: "/images")
-	ReqHandleConf				reqHandling_;    // 이 위치의 요청 처리 구성
+	std::string					path_;				// 위치 경로 (예: "/images")
+	RequestConfig				reqConfig_;		// 이 위치의 요청 처리 구성
 };
 
 // ServerConfig는 특정 서버의 구성을 나타냅니다.
 class ServerConfig {
 public:
-	std::string					host_;           // 호스트 이름 또는 IP 주소
-	unsigned int				port_;           // 수신 대기할 포트 번호
-	std::vector<std::string>	serverNames_;     // 서버 이름 별칭
-	ReqHandleConf				reqHandling_;    // 이 서버의 기본 요청 처리
-	std::vector<LocationConfig>	locations_;      // 위치별 구성 목록
+	ServerConfig() : port_(80) {}					// 포트를 80으로 기본 설정합니다.
 
-	// 기본 생성자는 원하는 경우 포트를 일반적인 기본값으로 초기화할 수 있습니다.
-	ServerConfig() : port_(80) {}                // 포트를 80으로 기본 설정합니다.
+	std::string					host_;				// 호스트 이름 또는 IP 주소
+	unsigned int				port_;				// 수신 대기할 포트 번호
+	std::vector<std::string>	serverNames_;		// 서버 이름 별칭
+	RequestConfig				reqConfig_;		// 이 서버의 기본 요청 처리
+	std::vector<LocationConfig>	locations_;			// 위치별 구성 목록
 };
 
 // GlobalConfig는 웹 서버의 전체 구성을 나타냅니다.
 class GlobalConfig {
 public:
-	std::vector<ServerConfig>	servers_;        // 서버 구성 목록
+	typedef std::map<int, std::vector<ServerConfig*> > ListenFdToServers;
+
+	std::vector<ServerConfig>	servers_;			// 서버 구성 목록
+	ListenFdToServers			listenFdToServers_;	// 리스닝 소켓 디스크립터 별 서버 구성 목록
+
+	// 리스닝 소켓 디스크립터, 도메인 이름, 대상 URL에 해당하는 요청 설정 찾기
+	const RequestConfig*		findRequestConfig(const int listenFd, \
+												const std::string& domainName, \
+												const std::string& targetUrl) const;
+	// 설정 정보 출력
 	void						print();
+
+private:
+	// 도메인 이름에 해당하는 서버 설정 찾기
+	const ServerConfig&			findServerConfig(const std::vector<ServerConfig*>& servers, \
+												const std::string& domainName) const;
+	// 대상 URI에 해당하는 location 설정 찾기
+	const RequestConfig*		findLocationConfig(const ServerConfig& server, \
+													const std::string& targetUrl) const;
 };

--- a/src/GlobalConfig/GlobalConfig.hpp
+++ b/src/GlobalConfig/GlobalConfig.hpp
@@ -26,7 +26,7 @@ public:
 class LocationConfig {
 public:
 	std::string					path_;				// 위치 경로 (예: "/images")
-	RequestConfig				reqConfig_;		// 이 위치의 요청 처리 구성
+	RequestConfig				reqConfig_;			// 이 위치의 요청 처리 구성
 };
 
 // ServerConfig는 특정 서버의 구성을 나타냅니다.
@@ -37,17 +37,17 @@ public:
 	std::string					host_;				// 호스트 이름 또는 IP 주소
 	unsigned int				port_;				// 수신 대기할 포트 번호
 	std::vector<std::string>	serverNames_;		// 서버 이름 별칭
-	RequestConfig				reqConfig_;		// 이 서버의 기본 요청 처리
+	RequestConfig				reqConfig_;			// 이 서버의 기본 요청 처리
 	std::vector<LocationConfig>	locations_;			// 위치별 구성 목록
 };
 
 // GlobalConfig는 웹 서버의 전체 구성을 나타냅니다.
 class GlobalConfig {
 public:
-	typedef std::map<int, std::vector<ServerConfig*> > ListenFdToServers;
+	typedef std::map<int, std::vector<ServerConfig*> > TypeListenFdToServers;
 
 	std::vector<ServerConfig>	servers_;			// 서버 구성 목록
-	ListenFdToServers			listenFdToServers_;	// 리스닝 소켓 디스크립터 별 서버 구성 목록
+	TypeListenFdToServers		listenFdToServers_;	// 리스닝 소켓 디스크립터 별 서버 구성 목록
 
 	// 리스닝 소켓 디스크립터, 도메인 이름, 대상 URL에 해당하는 요청 설정 찾기
 	const RequestConfig*		findRequestConfig(const int listenFd, \


### PR DESCRIPTION
## GlobalConfig::findRequestConfig() 구현
- GlobalConfig의 퍼블릭 메서드
- 리스닝 소켓 디스크립터, 도메인 이름, 대상 URL에 해당하는 요청 설정을 찾음.
 

findServerConfig() 구현
- findRequestConfig로부터 호출되어 도메인 이름에 해당하는 서버 설정을 찾음

findLocationConfig() 구현
- findRequestConfig로부터 호출되어 대상 URI에 해당하는 location 설정을 찾음

## 그 외 수정사항
- ConfigParser::parse()에서 서버 블록을 찾지 못하면 예외를 던지도록 수정

- 클래스명 ReqHandleConfig -> RequestConfig로 수정
- 멤버변수명 ReqHandleConfig::reqHandling -> reqConfig로 수정

 #25