### PR TITLE
feat: ClientSession 구현 및 RequestParser 테스트 가능

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,4 +5,8 @@ endif
 all clean fclean re:
 	$(MAKE) TOPDIR=`pwd` -C src $@
 
-.PHONY: all clean fclean re
+REQ_TEST_FILE=_request_msg_test.sh
+reqtest: $(REQ_TEST_FILE)
+	source $(REQ_TEST_FILE); ./webserv
+
+.PHONY: all clean fclean re reqtest

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ endif
 all clean fclean re:
 	$(MAKE) TOPDIR=`pwd` -C src $@
 
+SHELL = /bin/bash
 REQ_TEST_FILE=_request_msg_test.sh
 reqtest: $(REQ_TEST_FILE)
 	source $(REQ_TEST_FILE); ./webserv

--- a/_request_msg_test.sh
+++ b/_request_msg_test.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+export HTTP_REQUEST=$(echo -e $ERROR)
+
+BASIC="\
+GET /index.html HTTP/1.1\r\n\
+Host: localhost\r\n\
+Connection: keep-alive\r\n\
+Content-Length: 4\r\n\
+\r\n\
+hi\r\n\
+"
+
+CHUNK="\
+GET /index.html HTTP/1.1\r\n\
+Host: localhost\r\n\
+Connection: keep-alive\r\n\
+\r\n\
+4\r\n\
+hi\r\n\
+7\r\n\
+hello\r\n\
+0\r\n\
+"
+
+ERROR="\
+GET /index.html HTTP/1.1\r\n\
+\r\n\
+Host: localhost\r\n\
+Connection: keep-alive\r\n\
+Content-Length: 4\r\n\
+\r\n\
+hi\r\n\
+"

--- a/_request_msg_test.sh
+++ b/_request_msg_test.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-export HTTP_REQUEST=$(echo -e $ERROR)
-
 BASIC="\
 GET /index.html HTTP/1.1\r\n\
 Host: localhost\r\n\
@@ -32,3 +30,5 @@ Content-Length: 4\r\n\
 \r\n\
 hi\r\n\
 "
+
+export HTTP_REQUEST=$(printf "%b" "$BASIC")

--- a/src/ClientSession/ClientSession.cpp
+++ b/src/ClientSession/ClientSession.cpp
@@ -1,0 +1,72 @@
+#include "ClientSession.hpp"
+
+ClientSession::ClientSession(int listenFd, int clientFd) : status_(READ_CONTINUE), listenFd_(listenFd), clientFd_(clientFd), reqMsg_(NULL), config_(NULL) {}
+ClientSession::~ClientSession() {
+	if (this->reqMsg_ != NULL)
+		delete this->reqMsg_;
+}
+
+int ClientSession::getListenFd() const {
+	return this->listenFd_;
+}
+
+int ClientSession::getClientFd() const {
+	return this->clientFd_;
+}
+
+EnumSesStatus ClientSession::getStatus() const {
+	return this->status_;
+}
+
+std::string ClientSession::getReadBuffer() const {
+	return this->readBuffer_;
+}
+
+std::string ClientSession::getWriteBuffer() const {
+	return this->writeBuffer_;
+}
+
+void ClientSession::setListenFd(const int &listenFd) {
+	this->listenFd_ = listenFd;
+}
+
+void ClientSession::setClientFd(const int &clientFd) {
+	this->clientFd_ = clientFd;
+}
+
+void ClientSession::setStatus(const EnumSesStatus &status) {
+	this->status_ = status;
+}
+
+void ClientSession::setReadBuffer(const std::string &remainData) {
+	this->readBuffer_ = remainData;
+}
+
+void ClientSession::setWriteBuffer(const std::string &remainData) {
+	this->writeBuffer_ = remainData;
+}
+
+//Optional<ssize_t> ClientSession::getConfBodyMax() const {
+//	if (this->config_ == NULL)
+//		return Optional<ssize_t>();
+//	return this->config_->clientMaxBodySize_;//size_t & ssize_t는 맞춰봐야함
+//}
+
+#include <iostream>
+EnumSesStatus ClientSession::implementReqMsg(RequestParser &parser, const std::string &readData) {
+	if (this->reqMsg_ == NULL)
+		this->reqMsg_ = new RequestMessage();
+	
+	try {
+		//parser.setBodyMaxLength(this->config_);
+		this->readBuffer_ = parser.parse(this->readBuffer_ + readData, *this->reqMsg_);
+		//if (this->reqMsg_->getStatus() != DONE)
+		//	this->status_ = ;
+		//	?? throw?
+		this->reqMsg_->printResult();
+	} catch (const std::exception &e) {
+		std::cerr << e.what() << "\033[37;2m//in ClientSeesion.implementReqMsg()\033[0m" << std::endl;
+		this->status_ = CONNECTION_ERROR;
+	}
+	return this->status_;
+}

--- a/src/ClientSession/ClientSession.cpp
+++ b/src/ClientSession/ClientSession.cpp
@@ -26,6 +26,14 @@ std::string ClientSession::getWriteBuffer() const {
 	return this->writeBuffer_;
 }
 
+const RequestMessage *ClientSession::getReqMsg() const {
+	return this->reqMsg_;
+}
+
+const RequestConfig *ClientSession::getConfig() const {
+	return this->config_;
+}
+
 void ClientSession::setListenFd(const int &listenFd) {
 	this->listenFd_ = listenFd;
 }

--- a/src/ClientSession/ClientSession.hpp
+++ b/src/ClientSession/ClientSession.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "RequestParser.hpp"
+#include "GlobalConfig.hpp"
+#include "commonEnums.hpp"
+
+class ClientSession {
+	public:
+		ClientSession(int listenFd, int clientFd);
+		~ClientSession();
+
+		int					getListenFd() const;
+		int					getClientFd() const;
+		EnumSesStatus		getStatus() const;
+		std::string			getReadBuffer() const;
+		std::string			getWriteBuffer() const;
+		void				setListenFd(const int &listenFd);
+		void				setClientFd(const int &clientFd);
+		void				setStatus(const EnumSesStatus &status);
+		void				setReadBuffer(const std::string &remainData);
+		void				setWriteBuffer(const std::string &remainData);
+		
+		//Optional<ssize_t>	getConfBodyMax() const;
+		EnumSesStatus		implementReqMsg(RequestParser &parser, const std::string &readData);
+
+	private:
+		int					listenFd_;
+		int					errorStatusCode_;
+		int					clientFd_;
+		EnumSesStatus		status_;
+		RequestMessage		*reqMsg_;
+		RequestConfig		*config_;
+		std::string			readBuffer_;
+		std::string			writeBuffer_;
+};

--- a/src/ClientSession/ClientSession.hpp
+++ b/src/ClientSession/ClientSession.hpp
@@ -9,27 +9,29 @@ class ClientSession {
 		ClientSession(int listenFd, int clientFd);
 		~ClientSession();
 
-		int					getListenFd() const;
-		int					getClientFd() const;
-		EnumSesStatus		getStatus() const;
-		std::string			getReadBuffer() const;
-		std::string			getWriteBuffer() const;
-		void				setListenFd(const int &listenFd);
-		void				setClientFd(const int &clientFd);
-		void				setStatus(const EnumSesStatus &status);
-		void				setReadBuffer(const std::string &remainData);
-		void				setWriteBuffer(const std::string &remainData);
+		int						getListenFd() const;
+		int						getClientFd() const;
+		EnumSesStatus			getStatus() const;
+		std::string				getReadBuffer() const;
+		std::string				getWriteBuffer() const;
+		const RequestMessage	*getReqMsg() const;
+		const RequestConfig		*getConfig() const;
+		void					setListenFd(const int &listenFd);
+		void					setClientFd(const int &clientFd);
+		void					setStatus(const EnumSesStatus &status);
+		void					setReadBuffer(const std::string &remainData);
+		void					setWriteBuffer(const std::string &remainData);
 		
 		//Optional<ssize_t>	getConfBodyMax() const;
-		EnumSesStatus		implementReqMsg(RequestParser &parser, const std::string &readData);
+		EnumSesStatus			implementReqMsg(RequestParser &parser, const std::string &readData);
 
 	private:
-		int					listenFd_;
-		int					errorStatusCode_;
-		int					clientFd_;
-		EnumSesStatus		status_;
-		RequestMessage		*reqMsg_;
-		RequestConfig		*config_;
-		std::string			readBuffer_;
-		std::string			writeBuffer_;
+		int						listenFd_;
+		int						errorStatusCode_;
+		int						clientFd_;
+		EnumSesStatus			status_;
+		RequestMessage			*reqMsg_;
+		RequestConfig			*config_;
+		std::string				readBuffer_;
+		std::string				writeBuffer_;
 };

--- a/src/ClientSession/Makefile
+++ b/src/ClientSession/Makefile
@@ -1,0 +1,14 @@
+ifndef TOPDIR
+	TOPDIR = $(abspath ../../)
+endif
+ifndef SRCDIR
+	SRCDIR = $(abspath ../)
+endif
+
+NAME := ClientSession.a
+HEAD := ClientSession.hpp
+SRCS := $(wildcard *.cpp)
+
+include $(TOPDIR)/include_make/Variable.mk
+include $(TOPDIR)/include_make/Link.mk
+include $(TOPDIR)/include_make/Recipe_subsrc.mk

--- a/src/Makefile
+++ b/src/Makefile
@@ -19,7 +19,6 @@ DIRS := utils \
 		Demultiplexer \
 #		TimeoutHandler \# RequestParser 테스트를 위해 임시로 주석처리
 
-
 SUBS := $(addsuffix .a,$(DIRS))
 
 include $(TOPDIR)/include_make/Variable.mk

--- a/src/Makefile
+++ b/src/Makefile
@@ -14,6 +14,7 @@ DIRS := utils \
 		ConfigParser \
 		RequestMessage \
 		RequestParser \
+		ClientSession \
 		ServerManager \
 		Demultiplexer \
 #		TimeoutHandler \# RequestParser 테스트를 위해 임시로 주석처리

--- a/src/RequestMessage/RequestMessage.cpp
+++ b/src/RequestMessage/RequestMessage.cpp
@@ -88,12 +88,16 @@ void RequestMessage::printResult() const {
 	switch (this->method_) {
 		case NONE:
 			method = "NONE";
+			break;
 		case GET:
 			method = "GET";
+			break;
 		case POST:
 			method = "POST";
+			break;
 		case DELETE:
 			method = "DELETE";
+			break;
 	}
 	std::cout <<method<<";"<<std::endl;
 	
@@ -121,12 +125,12 @@ void RequestMessage::printBody(void) const {
 	std::cout << "\033[32;7m Body :\033[0m"<<std::endl;
 	std::cout <<"\033[37;2mcount: "<<this->body_.length()<<"\033[0m\n";
 	for (auto it = this->body_.begin(); it != this->body_.end(); ++it) {
-        if (*it == '\n')
-            std::cout << "\\n" << std::endl;
-        else if (*it == '\r')
-            std::cout << "\\r";
-        else
-            std::cout << *it;
+		if (*it == '\n')
+			std::cout << "\\n" << std::endl;
+		else if (*it == '\r')
+			std::cout << "\\r";
+		else
+			std::cout << *it;
 	}
 }
 void RequestMessage::printMetaData(void) const {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,10 +1,20 @@
+/*
 #include "GlobalConfig.hpp"
 #include "ConfigParser.hpp"
+*/
+
+#include "ClientSession.hpp"
+EnumSesStatus readRequest(ClientSession &curSession, RequestParser &parser);
 
 int main(int argc, char** argv) {
+	/*
     GlobalConfig globalConfig;
 
     ConfigParser::parse(globalConfig, argv[1]);
     globalConfig.print();
     return 0;
+	*/
+	ClientSession ses(0);
+	RequestParser parser;
+	readRequest(ses, parser);
 }

--- a/src/readRequest.cpp
+++ b/src/readRequest.cpp
@@ -6,6 +6,7 @@
 #define BUFFER_SIZE 8192 //== 8KB
 
 EnumSesStatus readRequest(ClientSession &curSession, RequestParser &parser) {
+	/* RECV 함수
 	std::string buffer;
 	buffer.resize(BUFFER_SIZE);
 
@@ -20,4 +21,15 @@ EnumSesStatus readRequest(ClientSession &curSession, RequestParser &parser) {
 			//handleAndResponse();
 		return requestResult;
 	}
+	*/
+	
+	const char* data = std::getenv("HTTP_REQUEST");
+	if (data == NULL) {
+		std::cerr << "환경변수 HTTP_REQUEST가 설정되지 않았습니다.\n";
+		exit(1);
+	}
+	EnumSesStatus requestResult = curSession.implementReqMsg(parser, std::string(data));
+	//if (requestResult == READ_COMPLETE)
+		//handleAndResponse();
+	return requestResult;
 }

--- a/src/readRequest.cpp
+++ b/src/readRequest.cpp
@@ -1,0 +1,23 @@
+#include <sys/socket.h>
+#include <iostream>
+#include <string>
+#include "ClientSession.hpp"
+
+#define BUFFER_SIZE 8192 //== 8KB
+
+EnumSesStatus readRequest(ClientSession &curSession, RequestParser &parser) {
+	std::string buffer;
+	buffer.resize(BUFFER_SIZE);
+
+	ssize_t res = recv(curSession.getClientFd(), &buffer[0], BUFFER_SIZE, MSG_DONTWAIT);
+	if (res == -1) {
+		std::cerr << "Error: systemcall error" << std::endl;
+		return (CONNECTION_ERROR);
+	} else if (res > 0) {
+		EnumSesStatus requestResult;
+		requestResult = curSession.implementReqMsg(parser, std::string(static_cast<char *>(buffer), res));
+		if (requestResult == READ_COMPLETE)
+			//handleAndResponse();
+		return requestResult;
+	}
+}


### PR DESCRIPTION
## 구현 내용
1. ClientSession 구현
2. EventHandler.handleClientRead() 내부의 readRequest() 기본 로직 임시로 구현
3. 테스트 기능
    - `main.cpp`에서 `readRequest()` 호출
    - `readRequest.cpp`에서 `recv()`가 아닌 방법으로 임시 구현
    - `_request_msg_test.sh`로 request message 입력