### PR TITLE
Feat: Event Handler 객체 구현

### DIFF
--- a/src/EventHandler/EventHandler.cpp
+++ b/src/EventHandler/EventHandler.cpp
@@ -1,0 +1,3 @@
+#include "EventHandler.hpp"
+
+

--- a/src/EventHandler/EventHandler.cpp
+++ b/src/EventHandler/EventHandler.cpp
@@ -1,3 +1,66 @@
 #include "EventHandler.hpp"
 
+EventHandler::EventHandler() {
+    // Q.필요한 멤버 변수 및 초기화 여부 + 초기화 시 필요한 정보
+}
+
+EventHandler::~EventHandler() {
+
+}
+
+// 서버 fd에서 발생한 Read 이벤트 처리
+int	EventHandler::handleServerReadEvent(int fd) {
+    struct sockaddr clientAddr;
+    socklen_t addrLen = sizeof(clientAddr);
+
+    int clientFd = accept(fd, (struct sockaddr*)&clientAddr, &addrLen);
+    if (clientFd < 0) {
+        perror("accept error");
+        return -1;
+    }
+
+    // Q.여기서 ClientSession 생성? + 생성시 필요한 정보 목록
+    // Q.IPv4와 IPv6에 따라 분기처리가 필요한 부분이 있는지
+
+    return clientFd;
+}
+
+
+// Q.recv, send status에 대한 매크로 혹은 enum 논의 필요
+// ServerManager, EventHandler에서 사용 => 공통 헤더 이용?
+
+// 클라이언트 fd에서 발생한 Read 이벤트 처리
+int	EventHandler::handleClientReadEvent(int fd) {
+    int status = readRequest();
+
+    if (status == DONE_READING) {
+        status = sendReponse();
+    }
+    return status;
+}
+
+// 클라이언트 fd에서 발생한 Write 이벤트 처리
+int EventHandler::handleClientWriteEvent(int fd) {
+    int status = sendResponse();
+    
+    return status;
+}
+
+// 예외 이벤트 처리
+void    EventHandler::handleExceptionEvent(int fd) {
+    // Q.Exception Event 발생 케이스 및 처리 내용 구체화
+}
+
+// timeout 처리(408반환)
+void	EventHandler::handleTimeout(int fd) {
+    // Q.error 핸들링 시에도 status 반환 필요할지
+    sendResponse(fd, 408);
+}
+
+// 서버 종료 전 연결되어 있는 client에 연결 종료 고지
+void	EventHandler::handleServerShutDown(int fd) {
+    sendResponse(fd, 503);
+}
+
+
 

--- a/src/EventHandler/EventHandler.cpp
+++ b/src/EventHandler/EventHandler.cpp
@@ -1,6 +1,6 @@
 #include "EventHandler.hpp"
 
-EventHandler::EventHandler() {
+EventHandler::EventHandler() : staticHandler_(rspBuilder_) {
 
 }
 
@@ -15,8 +15,7 @@ int	EventHandler::handleServerReadEvent(int fd) {
 
     int clientFd = accept(fd, (struct sockaddr*)&clientAddr, &addrLen);
     if (clientFd < 0) {
-        perror("accept error");
-        return -1;
+        perror("client accept error");
     }
 
     return clientFd;
@@ -24,35 +23,47 @@ int	EventHandler::handleServerReadEvent(int fd) {
 
 // 클라이언트 fd에서 발생한 Read 이벤트 처리
 int	EventHandler::handleClientReadEvent(ClientSession& clientSession) {
-    int status = readRequest(clientSession, parser_);
+    int status = readRequest(clientSession); // ! parser_넘겨줄 필요가 없음
+    //readRequest: EventHandler의 멤버 함수
+    //parser_: EventHandler의 멤버 변수
 
     if (status == READ_COMPLETE) {
-		std::string responseMsg;
+        RequestMessage* requestMsg = clientSession.getReqMsg();
+		std::string     responseMsg;
 
-		if (cgiHandler_.isCGI(clientSession.getPath())) {
-			responseMsg = cgiHandler.handleRequest(clientSession.getReqMsg(), clientSession.getConfig());
+        // CGI 실행 여부 판별 및 응답 생성
+        // 일단 requestMsg와 config가 nullptr일리가 없을 것 같아서 가드를 따로 하진 않았습니다.
+        // 그치만 nullptr일리 없다면, 애초에 레퍼런스여도 되지 않을까요..??!
+		if (cgiHandler_.isCGI(requestMsg->getTargetURI())) {
+			responseMsg = cgiHandler_.handleRequest(*requestMsg, *clientSession.getConfig());
 		} else {
-			responseMsg = staticHandler.handleRequest(clientSession.getReqMsg(), clientSession.getConfig());
+			responseMsg = staticHandler_.handleRequest(*requestMsg, *clientSession.getConfig());
 		}
+        // 생성된 응답을 clientSession 내 write 버퍼에 저장
 		clientSession.setWriteBuffer(responseMsg);
 		
+        // 응답 전송 시도 및 sessionStatus 갱신
         status = sendResponse(clientSession);
     }
+
     return status;
 }
 
 // 클라이언트 fd에서 발생한 Write 이벤트 처리
-<<<<<<< HEAD
 int EventHandler::handleClientWriteEvent(ClientSession& clientSession) {
+    // 응답 전송 시도 및 sessionStatus 갱신
     int status = sendResponse(clientSession);
     
     return status;
 }
 
 void	EventHandler::handleError(int statusCode, ClientSession& clientSession) {
-	clientSession.clearWriteBuffer(); // ClientSession 명세 확인 후 수정 예정
+	// 에러 응답 생성
+    std::string errorMsg = rspBuilder_.buildError(statusCode, clientSession.getConfig());
 
-	std::string errorMsg = rspBuilder_.buildError(statusCode);
+    // 생성된 응답을 clientSession 내 write 버퍼에 저장
+	clientSession.setWriteBuffer(errorMsg);
 
+    // 응답 전송
 	sendResponse(clientSession);
 }

--- a/src/EventHandler/EventHandler.cpp
+++ b/src/EventHandler/EventHandler.cpp
@@ -28,11 +28,15 @@ int	EventHandler::handleClientReadEvent(ClientSession& clientSession) {
     int status = readRequest(clientSession, parser_);
 
     if (status == TypeSesStatus::READ_COMPLETE) {
-		//cgi or static Handler 호출
+		std::string responseMsg;
 
-		//if (static) build response
-
-		//send response
+		if (cgiHandler_.isCGI(clientSession.getPath())) {
+			responseMsg = cgiHandler.handleRequest(clientSession.getReqMsg(), clientSession.getConfig());
+		} else {
+			responseMsg = staticHandler.handleRequest(clientSession.getReqMsg(), clientSession.getConfig());
+		}
+		clientSession.setWriteBuffer(responseMsg);
+		
         status = sendResponse(clientSession);
     }
     return status;

--- a/src/EventHandler/EventHandler.cpp
+++ b/src/EventHandler/EventHandler.cpp
@@ -25,7 +25,7 @@ int	EventHandler::handleServerReadEvent(int fd) {
 
 // 클라이언트 fd에서 발생한 Read 이벤트 처리
 int	EventHandler::handleClientReadEvent(ClientSession& clientSession) {
-    int status = readRequest(clientSession);
+    int status = readRequest(clientSession, parser_);
 
     if (status == TypeSesStatus::READ_COMPLETE) {
 		//cgi or static Handler 호출

--- a/src/EventHandler/EventHandler.cpp
+++ b/src/EventHandler/EventHandler.cpp
@@ -1,7 +1,7 @@
 #include "EventHandler.hpp"
 
 EventHandler::EventHandler() {
-    // Q.필요한 멤버 변수 및 초기화 여부 + 초기화 시 필요한 정보
+
 }
 
 EventHandler::~EventHandler() {
@@ -19,47 +19,46 @@ int	EventHandler::handleServerReadEvent(int fd) {
         return -1;
     }
 
-    // Q.여기서 ClientSession 생성? + 생성시 필요한 정보 목록
-    // Q.IPv4와 IPv6에 따라 분기처리가 필요한 부분이 있는지
-
     return clientFd;
 }
 
 
-// Q.recv, send status에 대한 매크로 혹은 enum 논의 필요
-// ServerManager, EventHandler에서 사용 => 공통 헤더 이용?
-
 // 클라이언트 fd에서 발생한 Read 이벤트 처리
-int	EventHandler::handleClientReadEvent(int fd) {
-    int status = readRequest();
+int	EventHandler::handleClientReadEvent(ClientSession& clientSession) {
+    int status = readRequest(clientSession);
 
-    if (status == DONE_READING) {
-        status = sendReponse();
+    if (status == TypeSesStatus::READ_COMPLETE) {
+		//cgi or static Handler 호출
+
+		//if (static) build response
+
+		//send response
+        status = sendResponse(clientSession);
     }
     return status;
 }
 
 // 클라이언트 fd에서 발생한 Write 이벤트 처리
-int EventHandler::handleClientWriteEvent(int fd) {
-    int status = sendResponse();
+int EventHandler::handleClientWriteEvent(ClientSession& clientSession) {
+    int status = sendResponse(clientSession);
     
     return status;
 }
 
 // 예외 이벤트 처리
-void    EventHandler::handleExceptionEvent(int fd) {
+void    EventHandler::handleExceptionEvent(ClientSession& clientSession) {
     // Q.Exception Event 발생 케이스 및 처리 내용 구체화
 }
 
 // timeout 처리(408반환)
-void	EventHandler::handleTimeout(int fd) {
+void	EventHandler::handleTimeout(ClientSession& clientSession) {
     // Q.error 핸들링 시에도 status 반환 필요할지
-    sendResponse(fd, 408);
+    sendErrorResponse(clientSession, 408);
 }
 
 // 서버 종료 전 연결되어 있는 client에 연결 종료 고지
-void	EventHandler::handleServerShutDown(int fd) {
-    sendResponse(fd, 503);
+void	EventHandler::handleServerShutDown(ClientSession& clientSession) {
+    sendErrorResponse(clientSession, 503);
 }
 
 

--- a/src/EventHandler/EventHandler.cpp
+++ b/src/EventHandler/EventHandler.cpp
@@ -60,6 +60,3 @@ void	EventHandler::handleTimeout(ClientSession& clientSession) {
 void	EventHandler::handleServerShutDown(ClientSession& clientSession) {
     sendErrorResponse(clientSession, 503);
 }
-
-
-

--- a/src/EventHandler/EventHandler.cpp
+++ b/src/EventHandler/EventHandler.cpp
@@ -22,12 +22,11 @@ int	EventHandler::handleServerReadEvent(int fd) {
     return clientFd;
 }
 
-
 // 클라이언트 fd에서 발생한 Read 이벤트 처리
 int	EventHandler::handleClientReadEvent(ClientSession& clientSession) {
     int status = readRequest(clientSession, parser_);
 
-    if (status == TypeSesStatus::READ_COMPLETE) {
+    if (status == READ_COMPLETE) {
 		std::string responseMsg;
 
 		if (cgiHandler_.isCGI(clientSession.getPath())) {
@@ -39,6 +38,7 @@ int	EventHandler::handleClientReadEvent(ClientSession& clientSession) {
 		
         status = sendResponse(clientSession);
     }
+
     return status;
 }
 
@@ -49,18 +49,10 @@ int EventHandler::handleClientWriteEvent(ClientSession& clientSession) {
     return status;
 }
 
-// 예외 이벤트 처리
-void    EventHandler::handleExceptionEvent(ClientSession& clientSession) {
-    // Q.Exception Event 발생 케이스 및 처리 내용 구체화
-}
+void	EventHandler::handleError(int statusCode, ClientSession& clientSession) {
+	clientSession.clearWriteBuffer(); // ClientSession 명세 확인 후 수정 예정
 
-// timeout 처리(408반환)
-void	EventHandler::handleTimeout(ClientSession& clientSession) {
-    // Q.error 핸들링 시에도 status 반환 필요할지
-    sendErrorResponse(clientSession, 408);
-}
+	std::string errorMsg = rspBuilder_.buildError(statusCode);
 
-// 서버 종료 전 연결되어 있는 client에 연결 종료 고지
-void	EventHandler::handleServerShutDown(ClientSession& clientSession) {
-    sendErrorResponse(clientSession, 503);
+	sendResponse(clientSession);
 }

--- a/src/EventHandler/EventHandler.hpp
+++ b/src/EventHandler/EventHandler.hpp
@@ -1,8 +1,32 @@
 #pragma once
 
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <unistd.h>
+#include <cstdio>
+
+//임시
+class RequestParser {};
+class IRequestHandler {};
+class ResponseBuilder {};
+
 class EventHandler {
 	public:
-
+		EventHandler();
+		~EventHandler();
+		int		handleServerReadEvent(int fd);
+		int		handleClientReadEvent(int fd);
+		int 	handleClientWriteEvent(int fd);
+		void	handleExceptionEvent(int fd);
+		void	handleTimeout(int fd);
+		void	handleServerShutDown(int fd);
+		
 	private:
-	
+		RequestParser	parser_;
+		IRequestHandler	handler_;
+		ResponseBuilder	rspBuilder_;
+
+		int		readRequest(); //rcv()
+		int		sendResponse(); //send()
+
 };

--- a/src/EventHandler/EventHandler.hpp
+++ b/src/EventHandler/EventHandler.hpp
@@ -22,9 +22,7 @@ class EventHandler {
 		int		handleServerReadEvent(int fd);
 		int		handleClientReadEvent(ClientSession& clientSession);
 		int 	handleClientWriteEvent(ClientSession& clientSession);
-		void	handleExceptionEvent(ClientSession& clientSession);
-		void	handleTimeout(ClientSession& clientSession);
-		void	handleServerShutDown(ClientSession& clientSession);
+		void	handleError(int statusCode, ClientSession& clientSession);
 		
 	private:
 		RequestParser	parser_;
@@ -34,6 +32,5 @@ class EventHandler {
 
 		int		readRequest(ClientSession& clientSession, RequestParser& parser); //rcv()
 		int		sendResponse(ClientSession& clientSession); //send()
-		int		sendErrorResponse(ClientSession& clientSession); 
 
 };

--- a/src/EventHandler/EventHandler.hpp
+++ b/src/EventHandler/EventHandler.hpp
@@ -8,6 +8,7 @@
 //임시
 #include "../include/commonEnums.hpp"
 #include "../ClientManager/ClientManager.hpp"
+
 class RequestParser {};
 class StaticHandler {};
 class CgiHandler {};

--- a/src/EventHandler/EventHandler.hpp
+++ b/src/EventHandler/EventHandler.hpp
@@ -6,8 +6,11 @@
 #include <cstdio>
 
 //임시
+#include "../include/commonEnums.hpp"
+#include "../ClientManager/ClientManager.hpp"
 class RequestParser {};
-class IRequestHandler {};
+class StaticHandler {};
+class CgiHandler {};
 class ResponseBuilder {};
 
 class EventHandler {
@@ -15,18 +18,20 @@ class EventHandler {
 		EventHandler();
 		~EventHandler();
 		int		handleServerReadEvent(int fd);
-		int		handleClientReadEvent(int fd);
-		int 	handleClientWriteEvent(int fd);
-		void	handleExceptionEvent(int fd);
-		void	handleTimeout(int fd);
-		void	handleServerShutDown(int fd);
+		int		handleClientReadEvent(ClientSession& clientSession);
+		int 	handleClientWriteEvent(ClientSession& clientSession);
+		void	handleExceptionEvent(ClientSession& clientSession);
+		void	handleTimeout(ClientSession& clientSession);
+		void	handleServerShutDown(ClientSession& clientSession);
 		
 	private:
 		RequestParser	parser_;
-		IRequestHandler	handler_;
+		StaticHandler	staticHandler_;
+		CgiHandler		cgiHandler_;
 		ResponseBuilder	rspBuilder_;
 
-		int		readRequest(); //rcv()
-		int		sendResponse(); //send()
+		int		readRequest(ClientSession& clientSession); //rcv()
+		int		sendResponse(ClientSession& clientSession); //send()
+		int		sendErrorResponse(ClientSession& clientSession); 
 
 };

--- a/src/EventHandler/EventHandler.hpp
+++ b/src/EventHandler/EventHandler.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <string>
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <unistd.h>

--- a/src/EventHandler/EventHandler.hpp
+++ b/src/EventHandler/EventHandler.hpp
@@ -1,0 +1,8 @@
+#pragma once
+
+class EventHandler {
+	public:
+
+	private:
+	
+};

--- a/src/EventHandler/EventHandler.hpp
+++ b/src/EventHandler/EventHandler.hpp
@@ -6,12 +6,17 @@
 #include <unistd.h>
 #include <cstdio>
 
-//임시
+//임시 인클루드
 #include "../include/commonEnums.hpp"
 #include "../ClientManager/ClientManager.hpp"
-
+#include "../RequestMessage/RequestMessage.hpp"
+//임시 클래스
 class RequestParser {};
-class StaticHandler {};
+class StaticHandler { 
+	public:
+		StaticHandler(ResponseBuilder& rspBuilder_);
+		~StaticHandler();
+};
 class CgiHandler {};
 class ResponseBuilder {};
 
@@ -26,11 +31,11 @@ class EventHandler {
 		
 	private:
 		RequestParser	parser_;
+		ResponseBuilder	rspBuilder_;
 		StaticHandler	staticHandler_;
 		CgiHandler		cgiHandler_;
-		ResponseBuilder	rspBuilder_;
 
-		int		readRequest(ClientSession& clientSession, RequestParser& parser); //rcv()
+		int		readRequest(ClientSession& clientSession); //rcv()
 		int		sendResponse(ClientSession& clientSession); //send()
 
 };

--- a/src/EventHandler/EventHandler.hpp
+++ b/src/EventHandler/EventHandler.hpp
@@ -31,7 +31,7 @@ class EventHandler {
 		CgiHandler		cgiHandler_;
 		ResponseBuilder	rspBuilder_;
 
-		int		readRequest(ClientSession& clientSession); //rcv()
+		int		readRequest(ClientSession& clientSession, RequestParser& parser); //rcv()
 		int		sendResponse(ClientSession& clientSession); //send()
 		int		sendErrorResponse(ClientSession& clientSession); 
 

--- a/src/EventHandler/EventHandlerReadRequest.cpp
+++ b/src/EventHandler/EventHandlerReadRequest.cpp
@@ -1,0 +1,6 @@
+#include "EventHandler.hpp"
+
+int	EventHandler::readRequest() {
+
+}
+

--- a/src/EventHandler/EventHandlerSendResponse.cpp
+++ b/src/EventHandler/EventHandlerSendResponse.cpp
@@ -1,0 +1,6 @@
+#include "EventHandler.hpp"
+
+int	EventHandler::sendResponse() {
+
+}
+

--- a/src/EventHandler/Makefile
+++ b/src/EventHandler/Makefile
@@ -1,0 +1,15 @@
+ifndef TOPDIR
+	TOPDIR = $(abspath ../../)
+endif
+ifndef SRCDIR
+	SRCDIR = $(abspath ../)
+endif
+
+NAME := EventHandler.a
+HEAD := EventHandler.hpp \
+
+SRCS := $(wildcard *.cpp)
+
+include $(TOPDIR)/include_make/Variable.mk
+include $(TOPDIR)/include_make/Link.mk
+include $(TOPDIR)/include_make/Recipe_subsrc.mk

--- a/src/ServerManager/ServerManagerRun.cpp
+++ b/src/ServerManager/ServerManagerRun.cpp
@@ -64,7 +64,7 @@ void ServerManager::cleanUpConnections(ClientManager& clientManager, EventHandle
 	std::map<int, ClientSession*>::iterator	it;
 
 	for (it = clientList.begin(); it != clientList.end(); ) {
-		eventHandler.handleServerShutDown(*it->second); // 클라이언트에게 서버 종료 알림
+		eventHandler.handleError(503, *it->second); // 클라이언트에게 서버 종료 알림
 		it = clientManager.removeClient(it->first); // 클라이언트 세션 삭제
 	}
 }

--- a/src/ServerManager/ServerManagerRun.cpp
+++ b/src/ServerManager/ServerManagerRun.cpp
@@ -11,12 +11,11 @@ void ServerManager::run() {
 		int	numEvents = reactor.waitForEvent(); // 발생한 이벤트 개수 확인
 
 		for (int i = 0; i < numEvents; ++i) {
-			TypeEvent	type = reactor.getEventType(i); // 이벤트 타입 확인
+			EnumEvent	type = reactor.getEventType(i); // 이벤트 타입 확인
 			int 		fd = reactor.getSocketFd(i); // 이벤트가 발생한 소켓 FD 확인
 
 			if (type == EXCEPTION_EVENT) { // 예외(오류) 이벤트 발생 시
-				// ((error response 전송 여부 판단 후 추가 가능))
-				removeClientInfo(fd, clientManager, reactor, timeoutHandler);
+				removeClientInfo(fd, clientManager, reactor, timeoutHandler); // 클라이언트 제거
 			} else if (type == READ_EVENT) { // 읽기(수신) 이벤트 발생 시
 				if (isServer(fd)) { // 서버 소켓이라면 새 클라이언트 연결 처리
 					int clientFd = eventHandler.handleServerReadEvent(fd);
@@ -26,12 +25,10 @@ void ServerManager::run() {
 					}
 
 				} else { // 클라이언트 소켓에서 데이터 수신 처리
-					TypeSesStatus	status = eventHandler.handleClientReadEvent(clientManager.accessClientSession(fd));
+					EnumSesStatus	status = eventHandler.handleClientReadEvent(clientManager.accessClientSession(fd));
 
 					if (status == CONNECTION_CLOSED) { // 클라이언트가 연결 종료
 						removeClientInfo(fd, clientManager, reactor, timeoutHandler);
-					} else if (status == CONNECTION_ERROR) { // 클라이언트 오류 발생
-						// ((connection error 처리 로직 추가 필요))
 					} else if (status == WRITE_CONTINUE) { // 추가적인 쓰기 작업 필요
 						timeoutHandler.updateActivity(fd); // 타임아웃 갱신
 						reactor.addWriteEvent(fd); // 쓰기 이벤트 추가
@@ -41,7 +38,7 @@ void ServerManager::run() {
 				}
 
 			} else if (type == WRITE_EVENT) { // 쓰기(송신) 이벤트 발생 시
-				TypeSesStatus	status = eventHandler.handleClientWriteEvent(clientManager.accessClientSession(fd));
+				EnumSesStatus	status = eventHandler.handleClientWriteEvent(clientManager.accessClientSession(fd));
 
 				if (status == CONNECTION_CLOSED) { // 클라이언트가 연결 종료
 					removeClientInfo(fd, clientManager, reactor, timeoutHandler);

--- a/src/TimeoutHandler/TimeoutHandler.cpp
+++ b/src/TimeoutHandler/TimeoutHandler.cpp
@@ -52,8 +52,8 @@ void    TimeoutHandler::checkTimeouts(EventHandler& eventHandler, Demultiplexer&
         int fd = it->second;
         
 		//send 408 error
-		//실제 handleError 구현 후 인자 수정 예정
-		eventHandler.handleError(408); 
+		ClientSession clientSession = clientManager.accessClientSession(fd);
+		eventHandler.handleError(408, clientSession); 
 
 		//client 정보 삭제
         removeConnection(fd, it);


### PR DESCRIPTION
### 제안 1. readRequest 인자 변경
@taerakim 
제안이라기보단 통보..?이지만 readRequest에서 parser를 넘겨드릴 필요가 없었습니다..!
둘다 EventHandler의 멤버이다보니 내부적으로 사용하시면 됩니다. 
기존에 작업하신 내용 옮기실 때 수정하시면 될 것 같습니다!

### 제안 2. ClientSession의 getConfig와 getReqMsg 반환형 변경 제안
@nowead @taerakim 
일단 기존 명세대로 포인터를 반환받으면, 역참조한 내용을 넘겨주도록 했습니다.
다만 각 값들이 null일리 없다....라고 생각하면서 null가드를 따로 하지 않았습니다. 
한편으로는 null일리 없다면 굳이 포인터일 필요가 있을지 모르겠습니다..! 레퍼런스로 변경하는게 어떨까요?
