### PR TITLE
feat: ServerManager::setupListeningSockets

### DIFF
--- a/src/Demultiplexer/KqueueDemultiplexer.cpp
+++ b/src/Demultiplexer/KqueueDemultiplexer.cpp
@@ -1,13 +1,13 @@
 #include "KqueueDemultiplexer.hpp"
 
-KqueueDemultiplexer::KqueueDemultiplexer(std::set<int>& serverFds) : eventList_(MAX_EVENT){
+KqueueDemultiplexer::KqueueDemultiplexer(std::set<int>& listenFds) : eventList_(MAX_EVENT){
 	kq_ = kqueue();
 	if (kq_ == -1) {
 		perror("kqueue creation failed");
 	}
 
 	std::set<int>::const_iterator it;
-	for (it = serverFds.begin(); it != serverFds.end(); ++it) {
+	for (it = listenFds.begin(); it != listenFds.end(); ++it) {
 		addSocketImpl(*it);
 	}
 }

--- a/src/Demultiplexer/KqueueDemultiplexer.hpp
+++ b/src/Demultiplexer/KqueueDemultiplexer.hpp
@@ -10,7 +10,7 @@
 
 class KqueueDemultiplexer : public DemultiplexerBase<KqueueDemultiplexer> {
 	public:
-		KqueueDemultiplexer(std::set<int>& serverFds);
+		KqueueDemultiplexer(std::set<int>& listenFds);
 		~KqueueDemultiplexer();
 		int			waitForEventImpl();
 		void		addSocketImpl(int fd);

--- a/src/GlobalConfig/GlobalConfig.hpp
+++ b/src/GlobalConfig/GlobalConfig.hpp
@@ -32,7 +32,7 @@ public:
 // ServerConfig는 특정 서버의 구성을 나타냅니다.
 class ServerConfig {
 public:
-	ServerConfig() : port_(80) {}					// 포트를 80으로 기본 설정합니다.
+	ServerConfig() : host_("0.0.0.0"), port_(80) {}	// 포트를 80으로 기본 설정합니다.
 
 	std::string					host_;				// 호스트 이름 또는 IP 주소
 	unsigned int				port_;				// 수신 대기할 포트 번호

--- a/src/ServerManager/ServerManager.cpp
+++ b/src/ServerManager/ServerManager.cpp
@@ -1,1 +1,90 @@
 #include "ServerManager.hpp"
+
+#include <iostream>
+#include <string>
+#include <map>
+#include <utility>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <unistd.h>
+
+void ServerManager::setupListeningSockets(GlobalConfig& globalConfig) {
+    // Map to associate a host/port pair with its corresponding socket file descriptor.
+    std::map<std::pair<std::string, int>, int> addressToSocket;
+
+    // Iterate over each virtual server configuration defined in the globalConfig.
+    for (size_t i = 0; i < globalConfig.servers_.size(); ++i) {
+        ServerConfig& server = globalConfig.servers_[i];
+
+        // Get the host and port for this server.
+        std::pair<std::string, int> key = std::make_pair(server.host_, server.port_);
+
+        int sockFd;
+        // Check if a socket for this host/port combination has already been created.
+        if (addressToSocket.find(key) != addressToSocket.end()) {
+            sockFd = addressToSocket[key];
+        } else {
+            // Create a new TCP socket.
+            sockFd = socket(AF_INET, SOCK_STREAM, 0);
+            if (sockFd < 0) {
+				throw std::runtime_error("Failed to create socket");
+            }
+
+            // Set the socket to non-blocking mode.
+            // Retrieve the current flags for the socket.
+            int flags = fcntl(sockFd, F_GETFL, 0);
+            if (flags == -1) {
+                close(sockFd);
+                throw std::runtime_error("Failed to get socket flags");
+            }
+            // Add the O_NONBLOCK flag to ensure non-blocking operations.
+            if (fcntl(sockFd, F_SETFL, flags | O_NONBLOCK) == -1) {
+                close(sockFd);
+                throw std::runtime_error("Failed to set socket flags");
+            }
+
+            // Set socket option to allow the reuse of local addresses.
+            int opt = 1;
+            if (setsockopt(sockFd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)) < 0) {
+                close(sockFd);
+                throw std::runtime_error("Failed to set socket options");
+            }
+
+            // Initialize the sockaddr_in structure to define the server's address.
+            sockaddr_in addr;
+            addr.sin_family = AF_INET;                 // Use IPv4.
+            addr.sin_port = htons(server.port_);       // Set the port, converting to network byte order.
+            if (server.host_ == "0.0.0.0") {
+                addr.sin_addr.s_addr = INADDR_ANY;       // Bind to all available interfaces.
+            } else {
+                // Convert the IP address from text to binary form.
+                if (inet_aton(host.c_str(), &addr.sin_addr) == 0) {
+                    close(sockFd);
+					throw std::runtime_error("Invalid IP address");
+                }
+            }
+
+            // Bind the socket to the specified IP address and port.
+            if (bind(sockFd, reinterpret_cast<struct sockaddr*>(&addr), sizeof(addr)) < 0) {
+                close(sockFd);
+				throw std::runtime_error("Failed to bind socket");
+            }
+
+            // Begin listening for incoming connections on the socket.
+            if (listen(sockFd, SOMAXCONN) < 0) {
+                close(sockFd);
+                throw std::runtime_error("Failed to listen on socket");
+            }
+
+            // Store the new socket in our mapping so we don't create duplicate sockets.
+            addressToSocket[key] = sockFd;
+            // Add the socket to the set of listening file descriptors.
+            listenFds_.insert(sockFd);
+        }
+
+        // Map this server configuration to the corresponding listening socket.
+        // This allows multiple server configurations to share the same socket.
+        globalConfig.listenFdToServers_[sockFd].push_back(&server);
+    }
+}

--- a/src/ServerManager/ServerManager.hpp
+++ b/src/ServerManager/ServerManager.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <set>
+#include "../GlobalConfig/GlobalConfig.hpp"
 #include "../Demultiplexer/KqueueDemultiplexer.hpp"
 #include "../TimeoutHandler/TimeoutHandler.hpp"
 #include "../EventHandler/EventHandler.hpp"
@@ -11,16 +12,21 @@ class ServerManager {
 		ServerManager();
 		~ServerManager();
 
-		void	run();
-		bool	isServer(int fd);
-		bool	isRunning();
+		void			setupListeningSockets(GlobalConfig& globalConfig);
+		void			cleanUpListeningSockets();
 
-	private:
-		std::set<int>	serverFds_;
-		bool			serverStatus_; //signal 핸들링과 관련 있으므로 논의 필요
+		void			run();
+		bool			isServerRunning();
 
-		void addClientInfo(int clientFd, ClientManager& clientManager, Demultiplexer& reactor, TimeoutHandler& timeoutHandler);
-		void removeClientInfo(int clientFd, ClientManager& clientManager, Demultiplexer& reactor, TimeoutHandler& timeoutHandler);
-		void cleanUpConnections(ClientManager& clientManager, eventHandler& eventHandler);
+		
+		private:
+		std::set<int>	listenFds_;
+		// bool			listenFdStatus_; //signal 핸들링과 관련 있으므로 논의 필요
+		
+		bool			isServer(int fd);
+		void			addClientInfo(int clientFd, ClientManager& clientManager, Demultiplexer& reactor, TimeoutHandler& timeoutHandler);
+		void 			removeClientInfo(int clientFd, ClientManager& clientManager, Demultiplexer& reactor, TimeoutHandler& timeoutHandler);
+		void 			cleanUpConnections(ClientManager& clientManager, eventHandler& eventHandler);
+
 
 };

--- a/src/ServerManager/ServerManagerRun.cpp
+++ b/src/ServerManager/ServerManagerRun.cpp
@@ -2,7 +2,7 @@
 
 // EventLoop 실행 함수
 void ServerManager::run() {
-	Demultiplexer	reactor(serverFds_); // I/O 멀티플렉싱을 위한 리액터 객체
+	Demultiplexer	reactor(listenFds_); // I/O 멀티플렉싱을 위한 리액터 객체
 	EventHandler 	eventHandler; // 이벤트 처리 담당 객체
 	TimeoutHandler	timeoutHandler; // 클라이언트 타임아웃 관리 객체
 	ClientManager	clientManager; // 클라이언트 세션 관리 객체


### PR DESCRIPTION
- ServerManager::setupListeningSockets 함수 추가
- serverFds -> listenFds로 변수명 변경
  사유: listenFd는 하나의 가상 서버를 대표하지 않음.
  여러 가상 서버가 하나의 listenFd를 공유할 수 있음.
- ServerManager::isRunning -> isServerRunning 변수명 변경

Issue Number: #51