### PR TITLE
feat: GlobalConfig 싱글톤 패턴으로 구현

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,4 +5,8 @@ endif
 all clean fclean re:
 	$(MAKE) TOPDIR=`pwd` -C src $@
 
-.PHONY: all clean fclean re
+REQ_TEST_FILE=_request_msg_test.sh
+reqtest: $(REQ_TEST_FILE)
+	source $(REQ_TEST_FILE); ./webserv
+
+.PHONY: all clean fclean re reqtest

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ endif
 all clean fclean re:
 	$(MAKE) TOPDIR=`pwd` -C src $@
 
+SHELL = /bin/bash
 REQ_TEST_FILE=_request_msg_test.sh
 reqtest: $(REQ_TEST_FILE)
 	source $(REQ_TEST_FILE); ./webserv

--- a/_request_msg_test.sh
+++ b/_request_msg_test.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+export HTTP_REQUEST=$(echo -e $ERROR)
+
+BASIC="\
+GET /index.html HTTP/1.1\r\n\
+Host: localhost\r\n\
+Connection: keep-alive\r\n\
+Content-Length: 4\r\n\
+\r\n\
+hi\r\n\
+"
+
+CHUNK="\
+GET /index.html HTTP/1.1\r\n\
+Host: localhost\r\n\
+Connection: keep-alive\r\n\
+\r\n\
+4\r\n\
+hi\r\n\
+7\r\n\
+hello\r\n\
+0\r\n\
+"
+
+ERROR="\
+GET /index.html HTTP/1.1\r\n\
+\r\n\
+Host: localhost\r\n\
+Connection: keep-alive\r\n\
+Content-Length: 4\r\n\
+\r\n\
+hi\r\n\
+"

--- a/_request_msg_test.sh
+++ b/_request_msg_test.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-export HTTP_REQUEST=$(echo -e $ERROR)
-
 BASIC="\
 GET /index.html HTTP/1.1\r\n\
 Host: localhost\r\n\
@@ -32,3 +30,5 @@ Content-Length: 4\r\n\
 \r\n\
 hi\r\n\
 "
+
+export HTTP_REQUEST=$(printf "%b" "$BASIC")

--- a/src/ClientSession/ClientSession.cpp
+++ b/src/ClientSession/ClientSession.cpp
@@ -1,0 +1,72 @@
+#include "ClientSession.hpp"
+
+ClientSession::ClientSession(int listenFd, int clientFd) : status_(READ_CONTINUE), listenFd_(listenFd), clientFd_(clientFd), reqMsg_(NULL), config_(NULL) {}
+ClientSession::~ClientSession() {
+	if (this->reqMsg_ != NULL)
+		delete this->reqMsg_;
+}
+
+int ClientSession::getListenFd() const {
+	return this->listenFd_;
+}
+
+int ClientSession::getClientFd() const {
+	return this->clientFd_;
+}
+
+EnumSesStatus ClientSession::getStatus() const {
+	return this->status_;
+}
+
+std::string ClientSession::getReadBuffer() const {
+	return this->readBuffer_;
+}
+
+std::string ClientSession::getWriteBuffer() const {
+	return this->writeBuffer_;
+}
+
+void ClientSession::setListenFd(const int &listenFd) {
+	this->listenFd_ = listenFd;
+}
+
+void ClientSession::setClientFd(const int &clientFd) {
+	this->clientFd_ = clientFd;
+}
+
+void ClientSession::setStatus(const EnumSesStatus &status) {
+	this->status_ = status;
+}
+
+void ClientSession::setReadBuffer(const std::string &remainData) {
+	this->readBuffer_ = remainData;
+}
+
+void ClientSession::setWriteBuffer(const std::string &remainData) {
+	this->writeBuffer_ = remainData;
+}
+
+//Optional<ssize_t> ClientSession::getConfBodyMax() const {
+//	if (this->config_ == NULL)
+//		return Optional<ssize_t>();
+//	return this->config_->clientMaxBodySize_;//size_t & ssize_t는 맞춰봐야함
+//}
+
+#include <iostream>
+EnumSesStatus ClientSession::implementReqMsg(RequestParser &parser, const std::string &readData) {
+	if (this->reqMsg_ == NULL)
+		this->reqMsg_ = new RequestMessage();
+	
+	try {
+		//parser.setBodyMaxLength(this->config_);
+		this->readBuffer_ = parser.parse(this->readBuffer_ + readData, *this->reqMsg_);
+		//if (this->reqMsg_->getStatus() != DONE)
+		//	this->status_ = ;
+		//	?? throw?
+		this->reqMsg_->printResult();
+	} catch (const std::exception &e) {
+		std::cerr << e.what() << "\033[37;2m//in ClientSeesion.implementReqMsg()\033[0m" << std::endl;
+		this->status_ = CONNECTION_ERROR;
+	}
+	return this->status_;
+}

--- a/src/ClientSession/ClientSession.cpp
+++ b/src/ClientSession/ClientSession.cpp
@@ -26,6 +26,14 @@ std::string ClientSession::getWriteBuffer() const {
 	return this->writeBuffer_;
 }
 
+const RequestMessage *ClientSession::getReqMsg() const {
+	return this->reqMsg_;
+}
+
+const RequestConfig *ClientSession::getConfig() const {
+	return this->config_;
+}
+
 void ClientSession::setListenFd(const int &listenFd) {
 	this->listenFd_ = listenFd;
 }

--- a/src/ClientSession/ClientSession.hpp
+++ b/src/ClientSession/ClientSession.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "RequestParser.hpp"
+#include "GlobalConfig.hpp"
+#include "commonEnums.hpp"
+
+class ClientSession {
+	public:
+		ClientSession(int listenFd, int clientFd);
+		~ClientSession();
+
+		int					getListenFd() const;
+		int					getClientFd() const;
+		EnumSesStatus		getStatus() const;
+		std::string			getReadBuffer() const;
+		std::string			getWriteBuffer() const;
+		void				setListenFd(const int &listenFd);
+		void				setClientFd(const int &clientFd);
+		void				setStatus(const EnumSesStatus &status);
+		void				setReadBuffer(const std::string &remainData);
+		void				setWriteBuffer(const std::string &remainData);
+		
+		//Optional<ssize_t>	getConfBodyMax() const;
+		EnumSesStatus		implementReqMsg(RequestParser &parser, const std::string &readData);
+
+	private:
+		int					listenFd_;
+		int					errorStatusCode_;
+		int					clientFd_;
+		EnumSesStatus		status_;
+		RequestMessage		*reqMsg_;
+		RequestConfig		*config_;
+		std::string			readBuffer_;
+		std::string			writeBuffer_;
+};

--- a/src/ClientSession/ClientSession.hpp
+++ b/src/ClientSession/ClientSession.hpp
@@ -9,27 +9,29 @@ class ClientSession {
 		ClientSession(int listenFd, int clientFd);
 		~ClientSession();
 
-		int					getListenFd() const;
-		int					getClientFd() const;
-		EnumSesStatus		getStatus() const;
-		std::string			getReadBuffer() const;
-		std::string			getWriteBuffer() const;
-		void				setListenFd(const int &listenFd);
-		void				setClientFd(const int &clientFd);
-		void				setStatus(const EnumSesStatus &status);
-		void				setReadBuffer(const std::string &remainData);
-		void				setWriteBuffer(const std::string &remainData);
+		int						getListenFd() const;
+		int						getClientFd() const;
+		EnumSesStatus			getStatus() const;
+		std::string				getReadBuffer() const;
+		std::string				getWriteBuffer() const;
+		const RequestMessage	*getReqMsg() const;
+		const RequestConfig		*getConfig() const;
+		void					setListenFd(const int &listenFd);
+		void					setClientFd(const int &clientFd);
+		void					setStatus(const EnumSesStatus &status);
+		void					setReadBuffer(const std::string &remainData);
+		void					setWriteBuffer(const std::string &remainData);
 		
 		//Optional<ssize_t>	getConfBodyMax() const;
-		EnumSesStatus		implementReqMsg(RequestParser &parser, const std::string &readData);
+		EnumSesStatus			implementReqMsg(RequestParser &parser, const std::string &readData);
 
 	private:
-		int					listenFd_;
-		int					errorStatusCode_;
-		int					clientFd_;
-		EnumSesStatus		status_;
-		RequestMessage		*reqMsg_;
-		RequestConfig		*config_;
-		std::string			readBuffer_;
-		std::string			writeBuffer_;
+		int						listenFd_;
+		int						errorStatusCode_;
+		int						clientFd_;
+		EnumSesStatus			status_;
+		RequestMessage			*reqMsg_;
+		RequestConfig			*config_;
+		std::string				readBuffer_;
+		std::string				writeBuffer_;
 };

--- a/src/ClientSession/Makefile
+++ b/src/ClientSession/Makefile
@@ -1,0 +1,14 @@
+ifndef TOPDIR
+	TOPDIR = $(abspath ../../)
+endif
+ifndef SRCDIR
+	SRCDIR = $(abspath ../)
+endif
+
+NAME := ClientSession.a
+HEAD := ClientSession.hpp
+SRCS := $(wildcard *.cpp)
+
+include $(TOPDIR)/include_make/Variable.mk
+include $(TOPDIR)/include_make/Link.mk
+include $(TOPDIR)/include_make/Recipe_subsrc.mk

--- a/src/ConfigParser/ConfigParser.hpp
+++ b/src/ConfigParser/ConfigParser.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "GlobalConfig.hpp"
+#include "../GlobalConfig/GlobalConfig.hpp"
 #include "utils.hpp"
 
 #include <string>            // std::string
@@ -10,6 +10,11 @@
 #include <stdexcept>         // std::runtime_error
 #include <cctype>            // std::isdigit, std::isxdigit, std::isspace, std::tolower
 #include <iterator>          // std::iterator
+
+class GlobalConfig;
+class ServerConfig;
+class LocationConfig;
+class RequestConfig;
 
 // 설정 파일 파서
 class ConfigParser {

--- a/src/ConfigParser/Makefile
+++ b/src/ConfigParser/Makefile
@@ -10,5 +10,6 @@ HEAD := ConfigParser.hpp
 SRCS := $(wildcard *.cpp)
 
 include $(TOPDIR)/include_make/Variable.mk
+CPPFLAGS += -I$(SRCDIR)/GlobalConfig
 include $(TOPDIR)/include_make/Link.mk
 include $(TOPDIR)/include_make/Recipe_subsrc.mk

--- a/src/Demultiplexer/KqueueDemultiplexer.cpp
+++ b/src/Demultiplexer/KqueueDemultiplexer.cpp
@@ -1,13 +1,13 @@
 #include "KqueueDemultiplexer.hpp"
 
-KqueueDemultiplexer::KqueueDemultiplexer(std::set<int>& serverFds) : eventList_(MAX_EVENT){
+KqueueDemultiplexer::KqueueDemultiplexer(std::set<int>& listenFds) : eventList_(MAX_EVENT){
 	kq_ = kqueue();
 	if (kq_ == -1) {
 		perror("kqueue creation failed");
 	}
 
 	std::set<int>::const_iterator it;
-	for (it = serverFds.begin(); it != serverFds.end(); ++it) {
+	for (it = listenFds.begin(); it != listenFds.end(); ++it) {
 		addSocketImpl(*it);
 	}
 }

--- a/src/Demultiplexer/KqueueDemultiplexer.hpp
+++ b/src/Demultiplexer/KqueueDemultiplexer.hpp
@@ -10,7 +10,7 @@
 
 class KqueueDemultiplexer : public DemultiplexerBase<KqueueDemultiplexer> {
 	public:
-		KqueueDemultiplexer(std::set<int>& serverFds);
+		KqueueDemultiplexer(std::set<int>& listenFds);
 		~KqueueDemultiplexer();
 		int			waitForEventImpl();
 		void		addSocketImpl(int fd);

--- a/src/GlobalConfig/GlobalConfig.hpp
+++ b/src/GlobalConfig/GlobalConfig.hpp
@@ -32,7 +32,7 @@ public:
 // ServerConfig는 특정 서버의 구성을 나타냅니다.
 class ServerConfig {
 public:
-	ServerConfig() : port_(80) {}					// 포트를 80으로 기본 설정합니다.
+	ServerConfig() : host_("0.0.0.0"), port_(80) {}	// 포트를 80으로 기본 설정합니다.
 
 	std::string					host_;				// 호스트 이름 또는 IP 주소
 	unsigned int				port_;				// 수신 대기할 포트 번호

--- a/src/GlobalConfig/GlobalConfig.hpp
+++ b/src/GlobalConfig/GlobalConfig.hpp
@@ -1,9 +1,13 @@
 #pragma once
 
 # include "Optional.hpp"
+# include "../ConfigParser/ConfigParser.hpp"
 # include <string>
 # include <vector>
 # include <map>
+# include <iostream>
+
+class ConfigParser;
 
 // RequestConfig는 요청 처리를 위한 설정을 나타냅니다.
 class RequestConfig {
@@ -49,18 +53,30 @@ public:
 	std::vector<ServerConfig>	servers_;			// 서버 구성 목록
 	TypeListenFdToServers		listenFdToServers_;	// 리스닝 소켓 디스크립터 별 서버 구성 목록
 
+	
+	static const GlobalConfig&	getInstance();	// 싱글톤 인스턴스를 반환 (오직 const 접근만 허용됨)
+	static void 				initGlobalConfig(const char* path);	// 설정 파일을 이용해 GlobalConfig를 초기화 (단 한 번만 호출 가능)
+	static void					destroyInstance();	// 싱글톤 인스턴스를 파괴
+
 	// 리스닝 소켓 디스크립터, 도메인 이름, 대상 URL에 해당하는 요청 설정 찾기
 	const RequestConfig*		findRequestConfig(const int listenFd, \
 												const std::string& domainName, \
 												const std::string& targetUrl) const;
 	// 설정 정보 출력
-	void						print();
+	void						print() const;
 
 private:
+	// 싱글톤 패턴을 적용하기 위해 생성자를 private으로 설정
+	GlobalConfig() {}
+	~GlobalConfig() {}
+
+	static GlobalConfig*	instance_;			// 싱글톤 인스턴스 포인터
+	static bool				isInitialized_;		// GlobalConfig 초기화 여부
+
 	// 도메인 이름에 해당하는 서버 설정 찾기
-	const ServerConfig&			findServerConfig(const std::vector<ServerConfig*>& servers, \
-												const std::string& domainName) const;
+	const ServerConfig&		findServerConfig(const std::vector<ServerConfig*>& servers, \
+											const std::string& domainName) const;
 	// 대상 URI에 해당하는 location 설정 찾기
-	const RequestConfig*		findLocationConfig(const ServerConfig& server, \
-													const std::string& targetUrl) const;
+	const RequestConfig*	findLocationConfig(const ServerConfig& server, \
+												const std::string& targetUrl) const;
 };

--- a/src/GlobalConfig/Makefile
+++ b/src/GlobalConfig/Makefile
@@ -10,5 +10,6 @@ HEAD := GlobalConfig.hpp
 SRCS := $(wildcard *.cpp)
 
 include $(TOPDIR)/include_make/Variable.mk
+CPPFLAGS += -I$(SRCDIR)/ConfigParser
 include $(TOPDIR)/include_make/Link.mk
 include $(TOPDIR)/include_make/Recipe_subsrc.mk

--- a/src/Makefile
+++ b/src/Makefile
@@ -19,7 +19,6 @@ DIRS := utils \
 		Demultiplexer \
 #		TimeoutHandler \# RequestParser 테스트를 위해 임시로 주석처리
 
-
 SUBS := $(addsuffix .a,$(DIRS))
 
 include $(TOPDIR)/include_make/Variable.mk

--- a/src/Makefile
+++ b/src/Makefile
@@ -12,12 +12,12 @@ SRCS := $(wildcard *.cpp)
 DIRS := utils \
 		GlobalConfig \
 		ConfigParser \
-		RequestMessage \
-		RequestParser \
-		ClientSession \
-		ServerManager \
-		Demultiplexer \
-#		TimeoutHandler \# RequestParser 테스트를 위해 임시로 주석처리
+		# RequestMessage \
+		# RequestParser \
+		# ServerManager \
+		# Demultiplexer \
+		# TimeoutHandler
+
 
 SUBS := $(addsuffix .a,$(DIRS))
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -14,6 +14,7 @@ DIRS := utils \
 		ConfigParser \
 		RequestMessage \
 		RequestParser \
+		ClientSession \
 		ServerManager \
 		Demultiplexer \
 #		TimeoutHandler \# RequestParser 테스트를 위해 임시로 주석처리

--- a/src/RequestMessage/RequestMessage.cpp
+++ b/src/RequestMessage/RequestMessage.cpp
@@ -88,12 +88,16 @@ void RequestMessage::printResult() const {
 	switch (this->method_) {
 		case NONE:
 			method = "NONE";
+			break;
 		case GET:
 			method = "GET";
+			break;
 		case POST:
 			method = "POST";
+			break;
 		case DELETE:
 			method = "DELETE";
+			break;
 	}
 	std::cout <<method<<";"<<std::endl;
 	
@@ -121,12 +125,12 @@ void RequestMessage::printBody(void) const {
 	std::cout << "\033[32;7m Body :\033[0m"<<std::endl;
 	std::cout <<"\033[37;2mcount: "<<this->body_.length()<<"\033[0m\n";
 	for (auto it = this->body_.begin(); it != this->body_.end(); ++it) {
-        if (*it == '\n')
-            std::cout << "\\n" << std::endl;
-        else if (*it == '\r')
-            std::cout << "\\r";
-        else
-            std::cout << *it;
+		if (*it == '\n')
+			std::cout << "\\n" << std::endl;
+		else if (*it == '\r')
+			std::cout << "\\r";
+		else
+			std::cout << *it;
 	}
 }
 void RequestMessage::printMetaData(void) const {

--- a/src/ResponseBuilder/ErrorPageResolver.cpp
+++ b/src/ResponseBuilder/ErrorPageResolver.cpp
@@ -1,0 +1,44 @@
+#include "ErrorPageResolver.hpp" // 헤더 파일 포함
+
+namespace ErrorPageResolver {
+	// 주어진 에러 코드에 해당하는 에러 페이지의 내용을 반환하는 함수
+	std::string resolveErrorPage(int errorCode, const std::map<int, std::string>& errorPages) {
+		std::string bodyContent; // 에러 페이지의 내용(본문)을 저장할 변수
+
+		// errorPages_ 맵에서 해당 에러 코드에 맞는 사용자 정의 에러 페이지 경로를 찾습니다.
+		std::map<int, std::string>::const_iterator it = errorPages.find(errorCode);
+		if (it != errorPages.end()) {
+			const std::string& customPath = it->second; // 사용자 정의 에러 페이지 파일 경로
+			bodyContent = FileUtilities::readFile(customPath); // 해당 파일을 읽어 내용 저장
+		}
+
+		// 사용자 정의 에러 페이지를 찾지 못했거나 파일 내용이 비어있다면 기본 에러 페이지를 사용합니다.
+		if (bodyContent.empty()) {
+			std::ostringstream defaultPath;
+			// 기본 에러 페이지 경로 생성: 기본 디렉토리 + "/error" + 에러코드 + ".html"
+			defaultPath << DEFAULT_ERROR_DIRECTORY << "/error" << errorCode << ".html"; // 에러페이지 파일 이름 컨벤션 필요!
+			bodyContent = FileUtilities::readFile(defaultPath.str()); // 기본 경로의 파일을 읽어 내용 저장
+		}
+
+		// 파일을 읽었는데도 내용이 없다면 빈 문자열로 처리
+		if (bodyContent.empty()) {
+			bodyContent = "";
+		}
+
+		return bodyContent; // 최종적으로 에러 페이지의 내용을 반환
+	}
+
+	std::string getReasonPhrase(int errorCode) {
+		switch (errorCode) {
+			case 200: return "OK";                    // 200: OK
+			case 400: return "Bad Request";           // 400: 잘못된 요청
+			case 403: return "Forbidden";             // 403: 접근 금지
+			case 404: return "Not Found";             // 404: 찾을 수 없음
+			case 405: return "Method Not Allowed";    // 405: 허용되지 않은 메소드
+			case 500: return "Internal Server Error"; // 500: 내부 서버 오류
+			default:  return "Error";                 // 그 외: 일반 에러
+		}
+	}
+}
+
+

--- a/src/ResponseBuilder/ErrorPageResolver.cpp
+++ b/src/ResponseBuilder/ErrorPageResolver.cpp
@@ -27,18 +27,6 @@ namespace ErrorPageResolver {
 
 		return bodyContent; // 최종적으로 에러 페이지의 내용을 반환
 	}
-
-	std::string getReasonPhrase(int errorCode) {
-		switch (errorCode) {
-			case 200: return "OK";                    // 200: OK
-			case 400: return "Bad Request";           // 400: 잘못된 요청
-			case 403: return "Forbidden";             // 403: 접근 금지
-			case 404: return "Not Found";             // 404: 찾을 수 없음
-			case 405: return "Method Not Allowed";    // 405: 허용되지 않은 메소드
-			case 500: return "Internal Server Error"; // 500: 내부 서버 오류
-			default:  return "Error";                 // 그 외: 일반 에러
-		}
-	}
 }
 
 

--- a/src/ResponseBuilder/ErrorPageResolver.hpp
+++ b/src/ResponseBuilder/ErrorPageResolver.hpp
@@ -10,5 +10,4 @@
 // ErrorPageResolver 클래스: 에러 코드에 따른 에러 페이지 파일을 찾고 내용을 반환하는 역할을 합니다.
 namespace ErrorPageResolver {
 	std::string resolveErrorPage(int errorCode, const std::map<int, std::string>& errorPages);
-	std::string getReasonPhrase(int errorCode);
 };

--- a/src/ResponseBuilder/ErrorPageResolver.hpp
+++ b/src/ResponseBuilder/ErrorPageResolver.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "file_utils.hpp"
+#include <sstream>
+#include <map>
+#include <string>
+
+#define DEFAULT_ERROR_DIRECTORY "../error/"
+
+// ErrorPageResolver 클래스: 에러 코드에 따른 에러 페이지 파일을 찾고 내용을 반환하는 역할을 합니다.
+namespace ErrorPageResolver {
+	std::string resolveErrorPage(int errorCode, const std::map<int, std::string>& errorPages);
+	std::string getReasonPhrase(int errorCode);
+};

--- a/src/ResponseBuilder/Makefile
+++ b/src/ResponseBuilder/Makefile
@@ -1,0 +1,14 @@
+ifndef TOPDIR
+	TOPDIR = $(abspath ../../)
+endif
+ifndef SRCDIR
+	SRCDIR = $(abspath ../)
+endif
+
+NAME := ResponseBuilder.a
+HEAD := ResponseBuilder.hpp ErrorPageResolver.hpp
+SRCS := $(wildcard *.cpp)
+
+include $(TOPDIR)/include_make/Variable.mk
+include $(TOPDIR)/include_make/Link.mk
+include $(TOPDIR)/include_make/Recipe_subsrc.mk

--- a/src/ResponseBuilder/ResponseBuilder.cpp
+++ b/src/ResponseBuilder/ResponseBuilder.cpp
@@ -1,0 +1,78 @@
+#include "ResponseBuilder.hpp"                     // ResponseBuilder 헤더 파일 포함
+
+// RFC1123 형식으로 현재 GMT 시각 문자열을 반환하는 함수
+static std::string getCurrentDateString() {
+    std::time_t now = std::time(NULL);            // 현재 시간을 얻음
+    char buf[100];                                // 날짜 문자열을 저장할 버퍼 선언
+    std::strftime(buf, sizeof(buf), "%a, %d %b %Y %H:%M:%S GMT", std::gmtime(&now)); // GMT 기준 포맷으로 시간 변환
+    return std::string(buf);                      // 변환된 문자열을 반환
+}
+
+ResponseBuilder::ResponseBuilder(const RequestConfig& conf) : currConf_(conf), statusCode_(200), reasonPhrase_("OK") {
+}
+
+ResponseBuilder::~ResponseBuilder() {
+}
+
+void ResponseBuilder::setStatus(int code, const std::string &reason){
+    statusCode_ = code;                           // 상태 코드를 설정
+    reasonPhrase_ = reason;                       // 상태 코드에 해당하는 이유 문구를 설정
+}
+
+void ResponseBuilder::addHeader(const std::string &key, const std::string &value){
+    headers_[key] = value;                        // 헤더 맵에 키와 값을 추가
+}
+
+void ResponseBuilder::setBody(const std::string &bodyContent){
+    body_ = bodyContent;                          // 응답 바디 내용을 설정
+
+    // 바디의 길이에 맞춰 Content-Length 헤더를 설정
+    std::ostringstream oss;                       // 문자열 스트림 생성
+    oss << body_.size();                          // 바디의 크기를 문자열로 변환
+    headers_["Content-Length"] = oss.str();       // Content-Length 헤더에 변환된 값 설정
+}
+
+// 현재 상태코드, reasonPhrase_, headers_, body_를 기반으로 최종 HTTP/1.1 응답 메시지 문자열을 조립하는 함수
+std::string ResponseBuilder::assembleResponse() const {
+    std::ostringstream oss;                       // 응답 메시지를 조립할 문자열 스트림 생성
+    oss << "HTTP/1.1 " << statusCode_ << " " << reasonPhrase_ << "\r\n"; // 상태라인 추가
+    oss << "Date: " << getCurrentDateString() << "\r\n"; // 현재 날짜 헤더 추가
+
+    // 설정된 모든 헤더들을 추가
+    for (std::map<std::string, std::string>::const_iterator it = headers_.begin();
+         it != headers_.end(); ++it)
+    {
+        oss << it->first << ": " << it->second << "\r\n"; // 각 헤더를 "키: 값" 형식으로 추가
+    }
+
+    oss << "\r\n";                                // 헤더와 바디 사이에 빈 줄 추가
+    oss << body_;                                 // 응답 바디 내용을 추가
+
+    return oss.str();                             // 완성된 응답 문자열 반환
+}
+
+// 일반 응답 문자열을 생성하는 함수
+std::string ResponseBuilder::build() const {
+    // 바디가 비어있고 Content-Length 헤더가 설정되지 않은 경우
+    if (body_.empty() && headers_.find("Content-Length") == headers_.end()) {
+        const_cast<ResponseBuilder*>(this)->headers_["Content-Length"] = "0"; // Content-Length를 "0"으로 설정 (const_cast 사용)
+    }
+    return assembleResponse();                    // 최종 응답 문자열을 반환
+}
+
+
+// 에러 응답 문자열을 생성하는 함수
+// ErrorPageResolver를 사용해 에러 페이지 HTML을 로드한 후,
+//  새로운 ResponseBuilder를 통해 에러 응답 문자열을 구성한다.
+std::string ResponseBuilder::buildError(int errorPageCode) const {
+    std::string errorReason = ErrorPageResolver::getReasonPhrase(errorPageCode); // 에러 코드에 따른 Reason Phrase 결정
+
+    std::string bodyContent = ErrorPageResolver::resolveErrorPage(errorPageCode, currConf_.errorPages_); // 에러 페이지 HTML 내용을 로드
+
+    ResponseBuilder errorBuilder(currConf_);      // 현재 설정을 기반으로 새로운 ResponseBuilder 생성
+    errorBuilder.setStatus(errorPageCode, errorReason); // 에러 상태 코드와 이유 설정
+    errorBuilder.addHeader("Content-Type", "text/html");  // Content-Type 헤더를 "text/html"로 설정
+    errorBuilder.setBody(bodyContent);              // 에러 페이지 내용을 바디에 설정
+
+    return errorBuilder.build();                    // 생성된 에러 응답 문자열 반환
+}

--- a/src/ResponseBuilder/ResponseBuilder.cpp
+++ b/src/ResponseBuilder/ResponseBuilder.cpp
@@ -1,78 +1,74 @@
-#include "ResponseBuilder.hpp"                     // ResponseBuilder 헤더 파일 포함
+#include "ResponseBuilder.hpp"	// ResponseBuilder 헤더 파일 포함
 
-// RFC1123 형식으로 현재 GMT 시각 문자열을 반환하는 함수
+// 현재 GMT 시간의 RFC1123 형식 문자열 반환
 static std::string getCurrentDateString() {
-    std::time_t now = std::time(NULL);            // 현재 시간을 얻음
-    char buf[100];                                // 날짜 문자열을 저장할 버퍼 선언
-    std::strftime(buf, sizeof(buf), "%a, %d %b %Y %H:%M:%S GMT", std::gmtime(&now)); // GMT 기준 포맷으로 시간 변환
-    return std::string(buf);                      // 변환된 문자열을 반환
+	// 현재 시간 가져오기
+	std::time_t now = std::time(NULL);
+	// 날짜 문자열 저장할 버퍼 선언
+	char buf[100];
+	// GMT 기준 날짜 포맷으로 변환
+	std::strftime(buf, sizeof(buf), "%a, %d %b %Y %H:%M:%S GMT", std::gmtime(&now));
+	// 변환된 문자열 반환
+	return std::string(buf);
 }
 
-ResponseBuilder::ResponseBuilder(const RequestConfig& conf) : currConf_(conf), statusCode_(200), reasonPhrase_("OK") {
+void ResponseBuilder::setContentLength(std::map<std::string, std::string>& headers, const std::string &body) const {
+	// 바디 길이를 기반으로 Content-Length 헤더 설정
+	std::ostringstream oss;	// 문자열 스트림 생성
+	oss << body.size();		// 바디 길이를 문자열로 변환
+	headers["Content-Length"] = oss.str();	// Content-Length 헤더에 값 설정
 }
 
-ResponseBuilder::~ResponseBuilder() {
+std::string ResponseBuilder::getReasonPhrase(int errorCode) const {
+	// 상태 코드에 따른 이유 구문 반환
+	switch (errorCode) {
+		case 200: return "OK";				// 200: OK
+		case 400: return "Bad Request";		// 400: 잘못된 요청
+		case 403: return "Forbidden";			// 403: 접근 거부
+		case 404: return "Not Found";			// 404: 찾을 수 없음
+		case 405: return "Method Not Allowed";	// 405: 허용되지 않은 메소드
+		case 500: return "Internal Server Error";	// 500: 내부 서버 오류
+		default:  return "Error";				// 그 외: 일반 오류
+	}
 }
 
-void ResponseBuilder::setStatus(int code, const std::string &reason){
-    statusCode_ = code;                           // 상태 코드를 설정
-    reasonPhrase_ = reason;                       // 상태 코드에 해당하는 이유 문구를 설정
+std::string ResponseBuilder::assembleResponse(int statusCode, const std::string& reasonPhrase, 
+	const std::map<std::string, std::string>& headers, const std::string& body) const {
+	// 최종 HTTP/1.1 응답 메시지 조립
+	std::ostringstream oss;	// 응답 메시지 스트림 생성
+	oss << "HTTP/1.1 " << statusCode << " " << reasonPhrase << "\r\n";	// 상태 라인 추가
+	oss << "Date: " << getCurrentDateString() << "\r\n";	// Date 헤더 추가
+
+	// 모든 헤더 추가
+	for (std::map<std::string, std::string>::const_iterator it = headers.begin(); it != headers.end(); ++it) {
+		oss << it->first << ": " << it->second << "\r\n";	// 헤더 추가
+	}
+
+	oss << "\r\n";	// 헤더와 바디 구분을 위한 빈 줄 추가
+	oss << body;	// 응답 바디 추가
+
+	return oss.str();	// 완성된 응답 메시지 반환
 }
 
-void ResponseBuilder::addHeader(const std::string &key, const std::string &value){
-    headers_[key] = value;                        // 헤더 맵에 키와 값을 추가
+std::string ResponseBuilder::build(int statusCode, const std::string& contentType, const std::string& body) const {
+	// 일반 응답 메시지 생성
+	std::string reason = getReasonPhrase(statusCode);	// 상태 코드에 따른 이유 구문 결정
+	std::map<std::string, std::string> headers;			// 헤더 저장용 맵
+
+	headers["Content-Type"] = contentType;	// Content-Type 헤더 설정
+	setContentLength(headers, body);			// Content-Length 헤더 설정
+
+	return assembleResponse(statusCode, reason, headers, body);	// 최종 응답 메시지 반환
 }
 
-void ResponseBuilder::setBody(const std::string &bodyContent){
-    body_ = bodyContent;                          // 응답 바디 내용을 설정
+std::string ResponseBuilder::buildError(int errorStatusCode, const RequestConfig& currConf) const {
+	// 에러 응답 메시지 생성
+	std::string errorReason = getReasonPhrase(errorStatusCode);	// 에러 코드에 따른 이유 구문 결정
+	std::map<std::string, std::string> headers;					// 헤더 저장용 맵
+	std::string body = ErrorPageResolver::resolveErrorPage(errorStatusCode, currConf.errorPages_);	// 에러 페이지 HTML 내용 불러오기
 
-    // 바디의 길이에 맞춰 Content-Length 헤더를 설정
-    std::ostringstream oss;                       // 문자열 스트림 생성
-    oss << body_.size();                          // 바디의 크기를 문자열로 변환
-    headers_["Content-Length"] = oss.str();       // Content-Length 헤더에 변환된 값 설정
-}
+	headers["Content-Type"] = "text/html";	// Content-Type 헤더 설정
+	setContentLength(headers, body);			// Content-Length 헤더 설정
 
-// 현재 상태코드, reasonPhrase_, headers_, body_를 기반으로 최종 HTTP/1.1 응답 메시지 문자열을 조립하는 함수
-std::string ResponseBuilder::assembleResponse() const {
-    std::ostringstream oss;                       // 응답 메시지를 조립할 문자열 스트림 생성
-    oss << "HTTP/1.1 " << statusCode_ << " " << reasonPhrase_ << "\r\n"; // 상태라인 추가
-    oss << "Date: " << getCurrentDateString() << "\r\n"; // 현재 날짜 헤더 추가
-
-    // 설정된 모든 헤더들을 추가
-    for (std::map<std::string, std::string>::const_iterator it = headers_.begin();
-         it != headers_.end(); ++it)
-    {
-        oss << it->first << ": " << it->second << "\r\n"; // 각 헤더를 "키: 값" 형식으로 추가
-    }
-
-    oss << "\r\n";                                // 헤더와 바디 사이에 빈 줄 추가
-    oss << body_;                                 // 응답 바디 내용을 추가
-
-    return oss.str();                             // 완성된 응답 문자열 반환
-}
-
-// 일반 응답 문자열을 생성하는 함수
-std::string ResponseBuilder::build() const {
-    // 바디가 비어있고 Content-Length 헤더가 설정되지 않은 경우
-    if (body_.empty() && headers_.find("Content-Length") == headers_.end()) {
-        const_cast<ResponseBuilder*>(this)->headers_["Content-Length"] = "0"; // Content-Length를 "0"으로 설정 (const_cast 사용)
-    }
-    return assembleResponse();                    // 최종 응답 문자열을 반환
-}
-
-
-// 에러 응답 문자열을 생성하는 함수
-// ErrorPageResolver를 사용해 에러 페이지 HTML을 로드한 후,
-//  새로운 ResponseBuilder를 통해 에러 응답 문자열을 구성한다.
-std::string ResponseBuilder::buildError(int errorPageCode) const {
-    std::string errorReason = ErrorPageResolver::getReasonPhrase(errorPageCode); // 에러 코드에 따른 Reason Phrase 결정
-
-    std::string bodyContent = ErrorPageResolver::resolveErrorPage(errorPageCode, currConf_.errorPages_); // 에러 페이지 HTML 내용을 로드
-
-    ResponseBuilder errorBuilder(currConf_);      // 현재 설정을 기반으로 새로운 ResponseBuilder 생성
-    errorBuilder.setStatus(errorPageCode, errorReason); // 에러 상태 코드와 이유 설정
-    errorBuilder.addHeader("Content-Type", "text/html");  // Content-Type 헤더를 "text/html"로 설정
-    errorBuilder.setBody(bodyContent);              // 에러 페이지 내용을 바디에 설정
-
-    return errorBuilder.build();                    // 생성된 에러 응답 문자열 반환
+	return assembleResponse(errorStatusCode, errorReason, headers, body);	// 에러 응답 메시지 반환
 }

--- a/src/ResponseBuilder/ResponseBuilder.hpp
+++ b/src/ResponseBuilder/ResponseBuilder.hpp
@@ -1,0 +1,42 @@
+#pragma once                                   // 중복 포함 방지
+
+#include "GlobalConfig.hpp"                     // 전역 설정 헤더 포함
+#include "ErrorPageResolver.hpp"                // 에러 페이지 해석기 헤더 포함
+#include <map>                                  // std::map 사용
+#include <string>                               // std::string 사용
+#include <ctime>                                // 시간 관련 함수 사용
+#include <sstream>                              // 문자열 스트림 사용
+#include <iostream>                             // 입출력 스트림 사용
+
+//  HTTP 응답을 조립하는 책임을 가진 클래스.
+// 상태 코드/Reason, 헤더, 바디 등을 받아 최종 HTTP 응답 문자열을 생성한다.
+// 일반 응답 생성 build()와 에러 응답 생성 buildError()를 제공한다.
+
+class ResponseBuilder {
+    public:
+        explicit ResponseBuilder(const RequestConfig &conf); // 생성자: 요청 핸들링 설정을 전달받음
+        ~ResponseBuilder();                                  // 소멸자
+
+        // 응답 상태, 헤더, 바디를 설정하는 함수들
+        void setStatus(int code, const std::string &reason); // 상태 코드와 이유를 설정
+        void addHeader(const std::string &key, const std::string &value); // 헤더를 추가
+        void setBody(const std::string &bodyContent);        // 응답 바디를 설정
+
+        // 일반 응답 문자열을 생성하는 함수
+        std::string build() const;                           // 최종 응답 문자열을 반환
+
+        // 에러 응답 문자열을 생성하는 함수
+        // (실제 에러 페이지 내용은 ErrorPageResolver가 결정 및 로드)
+        std::string buildError(int errorPageCode) const;
+
+    private:
+        const RequestConfig&                currConf_;    // 현재 요청 핸들링 설정
+        int                                 statusCode_;  // 응답 상태 코드
+        std::string                         reasonPhrase_; // 상태 코드에 해당하는 이유 문구
+        std::map<std::string, std::string>  headers_;     // 응답 헤더들을 저장하는 맵
+        std::string                         body_;        // 응답 바디 내용
+
+        // 내부에서 HTTP 응답 문자열을 조립하는 함수들
+        std::string assembleResponse() const;              // 전체 응답 문자열을 조립
+
+};

--- a/src/ResponseBuilder/ResponseBuilder.hpp
+++ b/src/ResponseBuilder/ResponseBuilder.hpp
@@ -1,42 +1,53 @@
-#pragma once                                   // 중복 포함 방지
+#ifndef RESPONSEBUILDER_HPP
+#define RESPONSEBUILDER_HPP
 
-#include "GlobalConfig.hpp"                     // 전역 설정 헤더 포함
-#include "ErrorPageResolver.hpp"                // 에러 페이지 해석기 헤더 포함
-#include <map>                                  // std::map 사용
-#include <string>                               // std::string 사용
-#include <ctime>                                // 시간 관련 함수 사용
-#include <sstream>                              // 문자열 스트림 사용
-#include <iostream>                             // 입출력 스트림 사용
+#include "GlobalConfig.hpp"
+#include "ErrorPageResolver.hpp"
 
-//  HTTP 응답을 조립하는 책임을 가진 클래스.
+#include <map>
+#include <string>
+#include <ctime>
+#include <sstream>
+#include <iostream>
+
+// HTTP 응답을 조립하는 클래스.
 // 상태 코드/Reason, 헤더, 바디 등을 받아 최종 HTTP 응답 문자열을 생성한다.
 // 일반 응답 생성 build()와 에러 응답 생성 buildError()를 제공한다.
-
 class ResponseBuilder {
-    public:
-        explicit ResponseBuilder(const RequestConfig &conf); // 생성자: 요청 핸들링 설정을 전달받음
-        ~ResponseBuilder();                                  // 소멸자
+public:
+	// 일반 응답 문자열을 생성하는 함수
+	// @param status       HTTP 상태 코드
+	// @param contentType  응답의 Content-Type 헤더 값
+	// @param body         응답 바디
+	// @return 최종 HTTP 응답 문자열
+	std::string build(int status, const std::string& contentType, const std::string& body) const;
 
-        // 응답 상태, 헤더, 바디를 설정하는 함수들
-        void setStatus(int code, const std::string &reason); // 상태 코드와 이유를 설정
-        void addHeader(const std::string &key, const std::string &value); // 헤더를 추가
-        void setBody(const std::string &bodyContent);        // 응답 바디를 설정
+	// 에러 응답 문자열을 생성하는 함수
+	// (실제 에러 페이지 내용은 ErrorPageResolver가 결정 및 로드)
+	// @param statusCode   HTTP 상태 코드
+	// @param currConf     현재 요청에 대한 설정
+	// @return 최종 에러 응답 문자열
+	std::string buildError(int statusCode, const RequestConfig& currConf) const;
 
-        // 일반 응답 문자열을 생성하는 함수
-        std::string build() const;                           // 최종 응답 문자열을 반환
+private:
 
-        // 에러 응답 문자열을 생성하는 함수
-        // (실제 에러 페이지 내용은 ErrorPageResolver가 결정 및 로드)
-        std::string buildError(int errorPageCode) const;
-
-    private:
-        const RequestConfig&                currConf_;    // 현재 요청 핸들링 설정
-        int                                 statusCode_;  // 응답 상태 코드
-        std::string                         reasonPhrase_; // 상태 코드에 해당하는 이유 문구
-        std::map<std::string, std::string>  headers_;     // 응답 헤더들을 저장하는 맵
-        std::string                         body_;        // 응답 바디 내용
-
-        // 내부에서 HTTP 응답 문자열을 조립하는 함수들
-        std::string assembleResponse() const;              // 전체 응답 문자열을 조립
-
+	// Content-Length 헤더를 설정하는 헬퍼함수
+	void setContentLength(std::map<std::string, std::string>& headers, 
+		const std::string& body) const;
+	
+	// 상태 코드에 대응하는 Reason Phrase를 반환하는 헬퍼함수
+	std::string getReasonPhrase(int statusCode) const;
+	
+	// 전체 HTTP 응답 문자열을 조립하는 헬퍼함수
+	// @param statusCode    HTTP 상태 코드
+	// @param reasonPhrase  상태 코드에 대응하는 Reason Phrase
+	// @param headers       헤더 맵
+	// @param body          응답 바디
+	// @return 최종 HTTP 응답 문자열
+	std::string assembleResponse(int statusCode,
+								const std::string& reasonPhrase,
+								const std::map<std::string, std::string>& headers,
+								const std::string& body) const;
 };
+
+#endif // RESPONSEBUILDER_HPP

--- a/src/ServerManager/ServerManager.cpp
+++ b/src/ServerManager/ServerManager.cpp
@@ -9,7 +9,16 @@
 #include <arpa/inet.h>
 #include <unistd.h>
 
-void ServerManager::setupListeningSockets(GlobalConfig& globalConfig) {
+void ServerManager::~ServerManager() {
+    for (std::set<int>::iterator it = listenFds_.begin(); it != listenFds_.end(); ++it) {
+        close(*it);
+    }
+    listenFds_.clear();
+}
+
+void ServerManager::setupListeningSockets() {
+	// Get the global configuration instance.
+	const GlobalConfig& globalConfig = GlobalConfig::getInstance();
     // Map to associate a host/port pair with its corresponding socket file descriptor.
     std::map<std::pair<std::string, int>, int> addressToSocket;
 

--- a/src/ServerManager/ServerManager.cpp
+++ b/src/ServerManager/ServerManager.cpp
@@ -1,1 +1,90 @@
 #include "ServerManager.hpp"
+
+#include <iostream>
+#include <string>
+#include <map>
+#include <utility>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <unistd.h>
+
+void ServerManager::setupListeningSockets(GlobalConfig& globalConfig) {
+    // Map to associate a host/port pair with its corresponding socket file descriptor.
+    std::map<std::pair<std::string, int>, int> addressToSocket;
+
+    // Iterate over each virtual server configuration defined in the globalConfig.
+    for (size_t i = 0; i < globalConfig.servers_.size(); ++i) {
+        ServerConfig& server = globalConfig.servers_[i];
+
+        // Get the host and port for this server.
+        std::pair<std::string, int> key = std::make_pair(server.host_, server.port_);
+
+        int sockFd;
+        // Check if a socket for this host/port combination has already been created.
+        if (addressToSocket.find(key) != addressToSocket.end()) {
+            sockFd = addressToSocket[key];
+        } else {
+            // Create a new TCP socket.
+            sockFd = socket(AF_INET, SOCK_STREAM, 0);
+            if (sockFd < 0) {
+				throw std::runtime_error("Failed to create socket");
+            }
+
+            // Set the socket to non-blocking mode.
+            // Retrieve the current flags for the socket.
+            int flags = fcntl(sockFd, F_GETFL, 0);
+            if (flags == -1) {
+                close(sockFd);
+                throw std::runtime_error("Failed to get socket flags");
+            }
+            // Add the O_NONBLOCK flag to ensure non-blocking operations.
+            if (fcntl(sockFd, F_SETFL, flags | O_NONBLOCK) == -1) {
+                close(sockFd);
+                throw std::runtime_error("Failed to set socket flags");
+            }
+
+            // Set socket option to allow the reuse of local addresses.
+            int opt = 1;
+            if (setsockopt(sockFd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)) < 0) {
+                close(sockFd);
+                throw std::runtime_error("Failed to set socket options");
+            }
+
+            // Initialize the sockaddr_in structure to define the server's address.
+            sockaddr_in addr;
+            addr.sin_family = AF_INET;                 // Use IPv4.
+            addr.sin_port = htons(server.port_);       // Set the port, converting to network byte order.
+            if (server.host_ == "0.0.0.0") {
+                addr.sin_addr.s_addr = INADDR_ANY;       // Bind to all available interfaces.
+            } else {
+                // Convert the IP address from text to binary form.
+                if (inet_aton(host.c_str(), &addr.sin_addr) == 0) {
+                    close(sockFd);
+					throw std::runtime_error("Invalid IP address");
+                }
+            }
+
+            // Bind the socket to the specified IP address and port.
+            if (bind(sockFd, reinterpret_cast<struct sockaddr*>(&addr), sizeof(addr)) < 0) {
+                close(sockFd);
+				throw std::runtime_error("Failed to bind socket");
+            }
+
+            // Begin listening for incoming connections on the socket.
+            if (listen(sockFd, SOMAXCONN) < 0) {
+                close(sockFd);
+                throw std::runtime_error("Failed to listen on socket");
+            }
+
+            // Store the new socket in our mapping so we don't create duplicate sockets.
+            addressToSocket[key] = sockFd;
+            // Add the socket to the set of listening file descriptors.
+            listenFds_.insert(sockFd);
+        }
+
+        // Map this server configuration to the corresponding listening socket.
+        // This allows multiple server configurations to share the same socket.
+        globalConfig.listenFdToServers_[sockFd].push_back(&server);
+    }
+}

--- a/src/ServerManager/ServerManager.hpp
+++ b/src/ServerManager/ServerManager.hpp
@@ -9,24 +9,19 @@
 
 class ServerManager {
 	public:
-		ServerManager();
 		~ServerManager();
 
-		void			setupListeningSockets(GlobalConfig& globalConfig);
-		void			cleanUpListeningSockets();
+		void			setupListeningSockets();
 
 		void			run();
 		bool			isServerRunning();
-
 		
 		private:
 		std::set<int>	listenFds_;
 		// bool			listenFdStatus_; //signal 핸들링과 관련 있으므로 논의 필요
 		
-		bool			isServer(int fd);
+		bool			isListeningSocket(int fd);
 		void			addClientInfo(int clientFd, ClientManager& clientManager, Demultiplexer& reactor, TimeoutHandler& timeoutHandler);
 		void 			removeClientInfo(int clientFd, ClientManager& clientManager, Demultiplexer& reactor, TimeoutHandler& timeoutHandler);
 		void 			cleanUpConnections(ClientManager& clientManager, eventHandler& eventHandler);
-
-
 };

--- a/src/ServerManager/ServerManager.hpp
+++ b/src/ServerManager/ServerManager.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <set>
+#include "../GlobalConfig/GlobalConfig.hpp"
 #include "../Demultiplexer/KqueueDemultiplexer.hpp"
 #include "../TimeoutHandler/TimeoutHandler.hpp"
 #include "../EventHandler/EventHandler.hpp"
@@ -11,16 +12,21 @@ class ServerManager {
 		ServerManager();
 		~ServerManager();
 
-		void	run();
-		bool	isServer(int fd);
-		bool	isRunning();
+		void			setupListeningSockets(GlobalConfig& globalConfig);
+		void			cleanUpListeningSockets();
 
-	private:
-		std::set<int>	serverFds_;
-		bool			serverStatus_; //signal 핸들링과 관련 있으므로 논의 필요
+		void			run();
+		bool			isServerRunning();
 
-		void addClientInfo(int clientFd, ClientManager& clientManager, Demultiplexer& reactor, TimeoutHandler& timeoutHandler);
-		void removeClientInfo(int clientFd, ClientManager& clientManager, Demultiplexer& reactor, TimeoutHandler& timeoutHandler);
-		void cleanUpConnections(ClientManager& clientManager, eventHandler& eventHandler);
+		
+		private:
+		std::set<int>	listenFds_;
+		// bool			listenFdStatus_; //signal 핸들링과 관련 있으므로 논의 필요
+		
+		bool			isServer(int fd);
+		void			addClientInfo(int clientFd, ClientManager& clientManager, Demultiplexer& reactor, TimeoutHandler& timeoutHandler);
+		void 			removeClientInfo(int clientFd, ClientManager& clientManager, Demultiplexer& reactor, TimeoutHandler& timeoutHandler);
+		void 			cleanUpConnections(ClientManager& clientManager, eventHandler& eventHandler);
+
 
 };

--- a/src/ServerManager/ServerManagerRun.cpp
+++ b/src/ServerManager/ServerManagerRun.cpp
@@ -18,7 +18,7 @@ void ServerManager::run() {
 				// ((error response 전송 여부 판단 후 추가 가능))
 				removeClientInfo(fd, clientManager, reactor, timeoutHandler);
 			} else if (type == READ_EVENT) { // 읽기(수신) 이벤트 발생 시
-				if (isServer(fd)) { // 서버 소켓이라면 새 클라이언트 연결 처리
+				if (isListeningSocket(fd)) { // 서버 소켓이라면 새 클라이언트 연결 처리
 					int clientFd = eventHandler.handleServerReadEvent(fd);
 
 					if (clientFd > 0) { // 새로운 클라이언트가 정상적으로 연결됨

--- a/src/ServerManager/ServerManagerRun.cpp
+++ b/src/ServerManager/ServerManagerRun.cpp
@@ -2,7 +2,7 @@
 
 // EventLoop 실행 함수
 void ServerManager::run() {
-	Demultiplexer	reactor(serverFds_); // I/O 멀티플렉싱을 위한 리액터 객체
+	Demultiplexer	reactor(listenFds_); // I/O 멀티플렉싱을 위한 리액터 객체
 	EventHandler 	eventHandler; // 이벤트 처리 담당 객체
 	TimeoutHandler	timeoutHandler; // 클라이언트 타임아웃 관리 객체
 	ClientManager	clientManager; // 클라이언트 세션 관리 객체

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,10 +1,8 @@
-/*
+#include <iostream>
 #include "GlobalConfig.hpp"
-#include "ConfigParser.hpp"
-*/
-
 #include "ClientSession.hpp"
 EnumSesStatus readRequest(ClientSession &curSession, RequestParser &parser);
+// #include "ServerManager.hpp"
 
 int main(int argc, char** argv) {
 	/*

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,10 +1,20 @@
+/*
 #include "GlobalConfig.hpp"
 #include "ConfigParser.hpp"
+*/
+
+#include "ClientSession.hpp"
+EnumSesStatus readRequest(ClientSession &curSession, RequestParser &parser);
 
 int main(int argc, char** argv) {
+	/*
     GlobalConfig globalConfig;
 
     ConfigParser::parse(globalConfig, argv[1]);
     globalConfig.print();
     return 0;
+	*/
+	ClientSession ses(0);
+	RequestParser parser;
+	readRequest(ses, parser);
 }

--- a/src/readRequest.cpp
+++ b/src/readRequest.cpp
@@ -6,6 +6,7 @@
 #define BUFFER_SIZE 8192 //== 8KB
 
 EnumSesStatus readRequest(ClientSession &curSession, RequestParser &parser) {
+	/* RECV 함수
 	std::string buffer;
 	buffer.resize(BUFFER_SIZE);
 
@@ -20,4 +21,15 @@ EnumSesStatus readRequest(ClientSession &curSession, RequestParser &parser) {
 			//handleAndResponse();
 		return requestResult;
 	}
+	*/
+	
+	const char* data = std::getenv("HTTP_REQUEST");
+	if (data == NULL) {
+		std::cerr << "환경변수 HTTP_REQUEST가 설정되지 않았습니다.\n";
+		exit(1);
+	}
+	EnumSesStatus requestResult = curSession.implementReqMsg(parser, std::string(data));
+	//if (requestResult == READ_COMPLETE)
+		//handleAndResponse();
+	return requestResult;
 }

--- a/src/readRequest.cpp
+++ b/src/readRequest.cpp
@@ -1,0 +1,23 @@
+#include <sys/socket.h>
+#include <iostream>
+#include <string>
+#include "ClientSession.hpp"
+
+#define BUFFER_SIZE 8192 //== 8KB
+
+EnumSesStatus readRequest(ClientSession &curSession, RequestParser &parser) {
+	std::string buffer;
+	buffer.resize(BUFFER_SIZE);
+
+	ssize_t res = recv(curSession.getClientFd(), &buffer[0], BUFFER_SIZE, MSG_DONTWAIT);
+	if (res == -1) {
+		std::cerr << "Error: systemcall error" << std::endl;
+		return (CONNECTION_ERROR);
+	} else if (res > 0) {
+		EnumSesStatus requestResult;
+		requestResult = curSession.implementReqMsg(parser, std::string(static_cast<char *>(buffer), res));
+		if (requestResult == READ_COMPLETE)
+			//handleAndResponse();
+		return requestResult;
+	}
+}


### PR DESCRIPTION
싱글톤 패턴으로 구현하기 위해 구현한
GlobalConfig의 static 멤버 함수와 멤버 변수들:
- 	getInstance();	// 싱글톤 인스턴스를 반환 (오직 const 접근만 허용됨)
	initGlobalConfig(const char* path);	// GlobalConfig를 초기화
	destroyInstance();					// 싱글톤 인스턴스를 파괴
-	GlobalConfig*	instance_;			// 싱글톤 인스턴스 포인터
	bool			isInitialized_;		// GlobalConfig 초기화 여부

- ServerManager::setupListeningSockets()의 매개변수(GlobalConfig&) 삭제
- 변수명 변경: ServerManager::isServer -> isListeningSocket
- ServerManager::cleanUpListeningSockets() 삭제
- 대신, ~ServerManager에서 리스닝 소켓을 해제하도록 구현

이슈 번호: #55