### PR TITLE
feat: RequestParser 정상화, 고도화 및 예외 처리 강화

### DIFF
--- a/src/ClientSession/ClientSession.cpp
+++ b/src/ClientSession/ClientSession.cpp
@@ -68,10 +68,12 @@ EnumSesStatus ClientSession::implementReqMsg(RequestParser &parser, const std::s
 	try {
 		//parser.setBodyMaxLength(this->config_);
 		this->readBuffer_ = parser.parse(this->readBuffer_ + readData, *this->reqMsg_);
-		//if (this->reqMsg_->getStatus() != DONE)
-		//	this->status_ = ;
-		//	?? throw?
-		this->reqMsg_->printResult();
+		if (this->reqMsg_->getStatus() == REQ_DONE) {
+			this->status_ = READ_COMPLETE;
+			this->reqMsg_->printResult();
+		}
+		//if (this->status_ == READ_CONTINUE)
+		//	std::cout << "READ_CONTINUE\n";
 	} catch (const std::exception &e) {
 		std::cerr << e.what() << "\033[37;2m//in ClientSeesion.implementReqMsg()\033[0m" << std::endl;
 		this->status_ = CONNECTION_ERROR;

--- a/src/ClientSession/ClientSession.cpp
+++ b/src/ClientSession/ClientSession.cpp
@@ -54,10 +54,10 @@ void ClientSession::setWriteBuffer(const std::string &remainData) {
 	this->writeBuffer_ = remainData;
 }
 
-//Optional<ssize_t> ClientSession::getConfBodyMax() const {
+//Optional<size_t> ClientSession::getConfBodyMax() const {
 //	if (this->config_ == NULL)
-//		return Optional<ssize_t>();
-//	return this->config_->clientMaxBodySize_;//size_t & ssize_t는 맞춰봐야함
+//		return Optional<size_t>();
+//	return this->config_->clientMaxBodySize_;
 //}
 
 #include <iostream>

--- a/src/ClientSession/ClientSession.hpp
+++ b/src/ClientSession/ClientSession.hpp
@@ -22,7 +22,7 @@ class ClientSession {
 		void					setReadBuffer(const std::string &remainData);
 		void					setWriteBuffer(const std::string &remainData);
 		
-		//Optional<ssize_t>	getConfBodyMax() const;
+		//Optional<size_t>	getConfBodyMax() const;
 		EnumSesStatus			implementReqMsg(RequestParser &parser, const std::string &readData);
 
 	private:

--- a/src/RequestMessage/RequestMessage.cpp
+++ b/src/RequestMessage/RequestMessage.cpp
@@ -2,8 +2,8 @@
 #include "utils.hpp"
 #include <stdexcept>
 
-RequestMessage::RequestMessage() : method_(NONE), status_(REQ_INIT) {}
-RequestMessage::RequestMessage(EnumMethod method, std::string targetURI) : method_(method), targetURI_(targetURI) {}
+RequestMessage::RequestMessage() : method_(NONE), status_(REQ_INIT), bodyLength_(0) {}
+RequestMessage::RequestMessage(EnumMethod method, std::string targetURI) : method_(method), targetURI_(targetURI), bodyLength_(0) {}
 RequestMessage::~RequestMessage() {}
 
 EnumMethod RequestMessage::getMethod() const {
@@ -22,6 +22,10 @@ std::string RequestMessage::getBody() const {
 	return this->body_;
 }
 
+size_t RequestMessage::getBodyLength() const {
+	return this->bodyLength_;
+}
+
 void RequestMessage::setMethod(const EnumMethod &method) {
 	this->method_ = method;
 }
@@ -30,16 +34,16 @@ void RequestMessage::setTargetURI(const std::string &targetURI) {
 	this->targetURI_ = targetURI;
 }
 
-void RequestMessage::addFields(std::string field, std::vector<std::string> values) {
+void RequestMessage::addFields(const std::string &field, const std::vector<std::string> &values) {
 	if (this->fieldLines_.find(field) == this->fieldLines_.end())
 		this->fieldLines_[field] = values;
 	else
 		throw std::exception();//already exist Header Field
 }
 
-void RequestMessage::addBody(std::string bodyData) {
+void RequestMessage::addBody(const std::string &bodyData) {
 	this->body_.append(bodyData);
-	this->body_.append("\r\n");
+	this->bodyLength_ += bodyData.length();
 }
 
 EnumReqStatus RequestMessage::getStatus() const {

--- a/src/RequestMessage/RequestMessage.cpp
+++ b/src/RequestMessage/RequestMessage.cpp
@@ -58,7 +58,7 @@ EnumConnection RequestMessage::getMetaConnection() const {
 	return this->metaConnection_;
 }
 
-ssize_t RequestMessage::getMetaContentLength() const {
+size_t RequestMessage::getMetaContentLength() const {
 	return this->metaContentLength_;
 }
 

--- a/src/RequestMessage/RequestMessage.cpp
+++ b/src/RequestMessage/RequestMessage.cpp
@@ -2,8 +2,8 @@
 #include "utils.hpp"
 #include <stdexcept>
 
-RequestMessage::RequestMessage() : method_(NONE), status_(REQ_INIT), bodyLength_(0) {}
-RequestMessage::RequestMessage(EnumMethod method, std::string targetURI) : method_(method), targetURI_(targetURI), bodyLength_(0) {}
+RequestMessage::RequestMessage() : method_(NONE), status_(REQ_INIT), bodyLength_(0), metaTransferEncoding_(NONE_ENCODING) {}
+RequestMessage::RequestMessage(EnumMethod method, std::string targetURI) : method_(method), targetURI_(targetURI), bodyLength_(0), metaTransferEncoding_(NONE_ENCODING) {}
 RequestMessage::~RequestMessage() {}
 
 EnumMethod RequestMessage::getMethod() const {
@@ -62,6 +62,10 @@ size_t RequestMessage::getMetaContentLength() const {
 	return this->metaContentLength_;
 }
 
+EnumTransEnc RequestMessage::getMetaTransferEncoding() const {
+	return this->metaTransferEncoding_;
+}
+
 void RequestMessage::setStatus(const EnumReqStatus &status) {
 	this->status_ = status;
 }
@@ -70,16 +74,16 @@ void RequestMessage::setMetaHost(const std::string &value) {
 	this->metaHost_ = value;
 }
 
-void RequestMessage::setMetaConnection(const std::string &value) {
-	if (value == "keep-alive")
-		this->metaConnection_ = KEEP_ALIVE;
-	if (value == "close")
-		this->metaConnection_ = CLOSE;
-	throw std::logic_error("Error: connection value");
+void RequestMessage::setMetaConnection(const EnumConnection &value) {
+	this->metaConnection_ = value;
 }
 
-void RequestMessage::setMetaContentLength(const std::string &value) {
-	this->metaContentLength_ = utils::sto_size_t(value);
+void RequestMessage::setMetaContentLength(const size_t &value) {
+	this->metaContentLength_ = value;
+}
+
+void RequestMessage::setMetaTransferEncoding(const EnumTransEnc &value) {
+	this->metaTransferEncoding_ = value;
 }
 
 // Parser 구현 후, 파싱 테스트용 함수, C++98 X

--- a/src/RequestMessage/RequestMessage.cpp
+++ b/src/RequestMessage/RequestMessage.cpp
@@ -2,8 +2,7 @@
 #include "utils.hpp"
 #include <stdexcept>
 
-RequestMessage::RequestMessage() : method_(NONE), status_(REQ_INIT), bodyLength_(0), metaTransferEncoding_(NONE_ENCODING) {}
-RequestMessage::RequestMessage(EnumMethod method, std::string targetURI) : method_(method), targetURI_(targetURI), bodyLength_(0), metaTransferEncoding_(NONE_ENCODING) {}
+RequestMessage::RequestMessage() : method_(NONE), bodyLength_(0), status_(REQ_INIT), metaConnection_(KEEP_ALIVE), metaContentLength_(0), metaTransferEncoding_(NONE_ENCODING) {}
 RequestMessage::~RequestMessage() {}
 
 EnumMethod RequestMessage::getMethod() const {
@@ -34,11 +33,13 @@ void RequestMessage::setTargetURI(const std::string &targetURI) {
 	this->targetURI_ = targetURI;
 }
 
-void RequestMessage::addFields(const std::string &field, const std::vector<std::string> &values) {
-	if (this->fieldLines_.find(field) == this->fieldLines_.end())
-		this->fieldLines_[field] = values;
-	else
-		throw std::exception();//already exist Header Field
+void RequestMessage::addFieldLine(const std::string &name, const std::vector<std::string> &values) {
+	if (this->fieldLines_.find(name) == this->fieldLines_.end())
+		this->fieldLines_[name] = values;
+	else {
+		std::vector<std::string> &finded = this->fieldLines_[name];
+		finded.insert(finded.end(), values.begin(), values.end());
+	}
 }
 
 void RequestMessage::addBody(const std::string &bodyData) {
@@ -66,6 +67,10 @@ EnumTransEnc RequestMessage::getMetaTransferEncoding() const {
 	return this->metaTransferEncoding_;
 }
 
+std::string RequestMessage::getMetaContentType() const {
+	return this->metaContentType_;
+}
+
 void RequestMessage::setStatus(const EnumReqStatus &status) {
 	this->status_ = status;
 }
@@ -84,6 +89,10 @@ void RequestMessage::setMetaContentLength(const size_t &value) {
 
 void RequestMessage::setMetaTransferEncoding(const EnumTransEnc &value) {
 	this->metaTransferEncoding_ = value;
+}
+
+void RequestMessage::setMetaContentType(const std::string &value) {
+	this->metaContentType_ = value;
 }
 
 // Parser 구현 후, 파싱 테스트용 함수, C++98 X

--- a/src/RequestMessage/RequestMessage.cpp
+++ b/src/RequestMessage/RequestMessage.cpp
@@ -75,7 +75,7 @@ void RequestMessage::setMetaConnection(const std::string &value) {
 }
 
 void RequestMessage::setMetaContentLength(const std::string &value) {
-	this->metaContentLength_ = utils::stosizet(value);
+	this->metaContentLength_ = utils::sto_size_t(value);
 }
 
 // Parser 구현 후, 파싱 테스트용 함수, C++98 X

--- a/src/RequestMessage/RequestMessage.hpp
+++ b/src/RequestMessage/RequestMessage.hpp
@@ -5,7 +5,8 @@
 #include <vector>
 
 enum EnumMethod { NONE, GET, POST, DELETE };
-enum EnumConnection { KEEP_ALIVE, CLOSE };
+typedef enum EnumConnection { KEEP_ALIVE, CLOSE } EnumConnect;
+typedef enum EnumTransferEncoding { NONE_ENCODING, CHUNK } EnumTransEnc;
 typedef enum EnumRequestStatus {
 	REQ_INIT,
 	REQ_TOP_CRLF,		// CRLF(0,1)
@@ -41,10 +42,12 @@ class RequestMessage {
 		std:: string	getMetaHost() const;
 		EnumConnection	getMetaConnection() const;
 		size_t			getMetaContentLength() const;
+		EnumTransEnc	getMetaTransferEncoding() const;
 		void			setStatus(const EnumReqStatus &status);
 		void			setMetaHost(const std::string &value);
-		void			setMetaConnection(const std::string &value);
-		void			setMetaContentLength(const std::string &value);
+		void			setMetaConnection(const EnumConnection &value);
+		void			setMetaContentLength(const size_t &value);
+		void			setMetaTransferEncoding(const EnumTransEnc &value);
 
 		// 파싱 후, 결과 출력을 위한 함수
 		void printResult() const;
@@ -64,6 +67,7 @@ class RequestMessage {
 		// Header Field에 작성되어있던 메타데이터
 		EnumReqStatus	status_;
 		std::string		metaHost_;
-		EnumConnection	metaConnection_;
+		EnumConnect		metaConnection_;
 		size_t			metaContentLength_;
+		EnumTransEnc	metaTransferEncoding_;
 };

--- a/src/RequestMessage/RequestMessage.hpp
+++ b/src/RequestMessage/RequestMessage.hpp
@@ -31,10 +31,11 @@ class RequestMessage {
 		std::string		getTargetURI() const;
 		TypeField		getFields() const;
 		std::string		getBody() const;
+		size_t			getBodyLength() const;
 		void			setMethod(const EnumMethod &method);
 		void			setTargetURI(const std::string &targetURI);
-		void			addFields(std::string field, std::vector<std::string> values);
-		void			addBody(std::string bodyData);
+		void			addFields(const std::string &field, const std::vector<std::string> &values);
+		void			addBody(const std::string &bodyData);
 		
 		EnumReqStatus	getStatus() const;
 		std:: string	getMetaHost() const;
@@ -58,6 +59,7 @@ class RequestMessage {
 		std::string		targetURI_;
 		TypeField		fieldLines_;
 		std::string		body_;
+		size_t			bodyLength_;
 
 		// Header Field에 작성되어있던 메타데이터
 		EnumReqStatus	status_;

--- a/src/RequestMessage/RequestMessage.hpp
+++ b/src/RequestMessage/RequestMessage.hpp
@@ -40,7 +40,7 @@ class RequestMessage {
 		EnumReqStatus	getStatus() const;
 		std:: string	getMetaHost() const;
 		EnumConnection	getMetaConnection() const;
-		ssize_t			getMetaContentLength() const;
+		size_t			getMetaContentLength() const;
 		void			setStatus(const EnumReqStatus &status);
 		void			setMetaHost(const std::string &value);
 		void			setMetaConnection(const std::string &value);
@@ -65,5 +65,5 @@ class RequestMessage {
 		EnumReqStatus	status_;
 		std::string		metaHost_;
 		EnumConnection	metaConnection_;
-		ssize_t			metaContentLength_;
+		size_t			metaContentLength_;
 };

--- a/src/RequestMessage/RequestMessage.hpp
+++ b/src/RequestMessage/RequestMessage.hpp
@@ -25,7 +25,6 @@ class RequestMessage {
 		typedef std::map<std::string, std::vector<std::string> >	TypeField;
 
 		RequestMessage();
-		RequestMessage(EnumMethod method, std::string target);
 		~RequestMessage();
 
 		EnumMethod		getMethod() const;
@@ -35,7 +34,7 @@ class RequestMessage {
 		size_t			getBodyLength() const;
 		void			setMethod(const EnumMethod &method);
 		void			setTargetURI(const std::string &targetURI);
-		void			addFields(const std::string &field, const std::vector<std::string> &values);
+		void			addFieldLine(const std::string &name, const std::vector<std::string> &values);
 		void			addBody(const std::string &bodyData);
 		
 		EnumReqStatus	getStatus() const;
@@ -43,11 +42,13 @@ class RequestMessage {
 		EnumConnection	getMetaConnection() const;
 		size_t			getMetaContentLength() const;
 		EnumTransEnc	getMetaTransferEncoding() const;
+		std:: string	getMetaContentType() const;
 		void			setStatus(const EnumReqStatus &status);
 		void			setMetaHost(const std::string &value);
 		void			setMetaConnection(const EnumConnection &value);
 		void			setMetaContentLength(const size_t &value);
 		void			setMetaTransferEncoding(const EnumTransEnc &value);
+		void			setMetaContentType(const std::string &value);
 
 		// 파싱 후, 결과 출력을 위한 함수
 		void printResult() const;
@@ -70,4 +71,5 @@ class RequestMessage {
 		EnumConnect		metaConnection_;
 		size_t			metaContentLength_;
 		EnumTransEnc	metaTransferEncoding_;
+		std::string		metaContentType_;
 };

--- a/src/RequestParser/RequestParser.hpp
+++ b/src/RequestParser/RequestParser.hpp
@@ -22,8 +22,8 @@ class RequestParser {
 		EnumReqStatus	handleCRLFLine(const EnumReqStatus &curStatus);
 		void			parseStartLine(const std::string &line, RequestMessage &reqMsg);
 		void			parseFieldLine(const std::string &line, RequestMessage &reqMsg);
-		std::string 	parseBody(const std::string &line, RequestMessage &reqMsg);
-		void			handleFieldValue(const std::string &name, const std::string &value, RequestMessage &reqMsg);
+		bool			validateFieldValue(const std::string &name, const int count);
+		bool			handleFieldValue(const std::string &name, const std::string &value, RequestMessage &reqMsg);
 		std::string		cleanUpChunkedBody(const std::string &data, RequestMessage &reqMsg);
+		std::string 	parseBody(const std::string &line, RequestMessage &reqMsg);
 };
-

--- a/src/RequestParser/RequestParser.hpp
+++ b/src/RequestParser/RequestParser.hpp
@@ -23,6 +23,7 @@ class RequestParser {
 		void			parseStartLine(const std::string &line, RequestMessage &reqMsg);
 		void			parseFieldLine(const std::string &line, RequestMessage &reqMsg);
 		std::string 	parseBody(const std::string &line, RequestMessage &reqMsg);
-		//void				cleanUpChunkedBody(const std::string &line);
+		void			handleFieldValue(const std::string &name, const std::string &value, RequestMessage &reqMsg);
+		std::string		cleanUpChunkedBody(const std::string &data, RequestMessage &reqMsg);
 };
 

--- a/src/RequestParser/RequestParser.hpp
+++ b/src/RequestParser/RequestParser.hpp
@@ -19,10 +19,10 @@ class RequestParser {
 		//Optional<ssize_t>	bodyMaxLength_;//Client마다 바뀌는 설정 값
 		
 		void			handleOneLine(const std::string &line, RequestMessage &reqMsg);
-		EnumReqStatus	setStatusCRLF(const EnumReqStatus &curStatus);
+		EnumReqStatus	handleCRLFLine(const EnumReqStatus &curStatus);
 		void			parseStartLine(const std::string &line, RequestMessage &reqMsg);
 		void			parseFieldLine(const std::string &line, RequestMessage &reqMsg);
-		void			parseBody(const std::string &line, RequestMessage &reqMsg);
+		std::string 	parseBody(const std::string &line, RequestMessage &reqMsg);
 		//void				cleanUpChunkedBody(const std::string &line);
 };
 

--- a/src/RequestParser/RequestParser.hpp
+++ b/src/RequestParser/RequestParser.hpp
@@ -22,7 +22,7 @@ class RequestParser {
 		EnumReqStatus	handleCRLFLine(const EnumReqStatus &curStatus);
 		void			parseStartLine(const std::string &line, RequestMessage &reqMsg);
 		void			parseFieldLine(const std::string &line, RequestMessage &reqMsg);
-		bool			validateFieldValue(const std::string &name, const int count);
+		bool			validateFieldValueCount(const std::string &name, const int count);
 		bool			handleFieldValue(const std::string &name, const std::string &value, RequestMessage &reqMsg);
 		std::string		cleanUpChunkedBody(const std::string &data, RequestMessage &reqMsg);
 		std::string 	parseBody(const std::string &line, RequestMessage &reqMsg);

--- a/src/RequestParser/RequestParser.hpp
+++ b/src/RequestParser/RequestParser.hpp
@@ -11,12 +11,12 @@ class RequestParser {
 		~RequestParser();
 
 		std::string		parse(const std::string &readData, RequestMessage &reqMsg);
-		//void			setBodyMaxLength(ssize_t length);
+		//void			setBodyMaxLength(size_t length);
 
 	private:
-		ssize_t			oneLineMaxLength_;
-		ssize_t			uriMaxLength_;
-		//Optional<ssize_t>	bodyMaxLength_;//Client마다 바뀌는 설정 값
+		size_t			oneLineMaxLength_;
+		size_t			uriMaxLength_;
+		//Optional<size_t>	bodyMaxLength_;//Client마다 바뀌는 설정 값
 		
 		void			handleOneLine(const std::string &line, RequestMessage &reqMsg);
 		EnumReqStatus	handleCRLFLine(const EnumReqStatus &curStatus);

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -36,7 +36,7 @@ namespace utils {
 	}
 
 	// 문자열을 size_t로 변환하는 함수
-	size_t stosizet(const std::string& str) {
+	size_t sto_size_t(const std::string& str) {
 		char* end;
 		errno = 0;
 		unsigned long result = std::strtoul(str.c_str(), &end, 10);
@@ -52,4 +52,19 @@ namespace utils {
 
 		return static_cast<size_t>(result);
 	}
+
+	std::string strtrim(const std::string& str) {
+		// 앞쪽 공백 제거
+		size_t start = 0;
+		while (start < str.size() && std::isspace(str[start]))
+			++start;
+
+		// 뒤쪽 공백 제거
+		size_t end = str.size();
+		while (end > start && std::isspace(str[end - 1]))
+			--end;
+
+		return str.substr(start, end - start);
+	}
+
 }

--- a/src/utils/utils.hpp
+++ b/src/utils/utils.hpp
@@ -17,7 +17,9 @@ namespace utils {
 	// 문자열을 int로 변환하는 함수
 	int stoi(const std::string& str);
 	// 문자열을 size_t로 변환하는 함수
-	size_t stosizet(const std::string& str);
+	size_t sto_size_t(const std::string& str);
+	// 문자열의 양쪽 공백을 제거하는 함수
+	std::string strtrim(const std::string& str);
 
 	// 입력 반복자 [first, last) 범위 내의 모든 요소가
 	// 주어진 조건(pred)을 만족하는지 확인하는 템플릿 함수


### PR DESCRIPTION
## 구현 기능 및 작업
- READ_CONTINUE시 처리 로직 (<- readBuffer)
- Body와 Content-Length
- 청크 전송 처리
- Request완료시 메타데이터 default값 설정
- field-line파싱 고도화
- ssize_t -> size_t 변경
