### PR TITLE
refactor:Demultiplexer

### DIFF
--- a/src/Demultiplexer/DemultiplexerBase.hpp
+++ b/src/Demultiplexer/DemultiplexerBase.hpp
@@ -1,8 +1,8 @@
 #ifndef DEMULTIPLEXER_BASE_HPP
 #define DEMULTIPLEXER_BASE_HPP
 
-#include "../include/commonEnums.hpp"
-#define MAX_EVENT 1024
+#include "commonEnums.hpp"
+static const int MAX_EVENT = 1024;
 
 template <typename Derived>
 class DemultiplexerBase {
@@ -13,7 +13,7 @@ class DemultiplexerBase {
 		void		addWriteEvent(int fd);
 		void		removeWriteEvent(int fd);
 		int			getSocketFd(int idx);
-		TypeEvent	getEventType(int idx);
+		EnumEvent	getEventType(int idx);
 	
 	protected:
 		DemultiplexerBase();

--- a/src/Demultiplexer/DemultiplexerBase.tpp
+++ b/src/Demultiplexer/DemultiplexerBase.tpp
@@ -1,6 +1,16 @@
 #include "DemultiplexerBase.hpp"
 
 template <typename Derived>
+DemultiplexerBase<Derived>::DemultiplexerBase() {
+
+}
+
+template <typename Derived>
+DemultiplexerBase<Derived>::~DemultiplexerBase() {
+
+}
+
+template <typename Derived>
 int DemultiplexerBase<Derived>::waitForEvent() {
 	return static_cast<Derived&>(*this).waitForEventImpl();
 }

--- a/src/Demultiplexer/DemultiplexerBase.tpp
+++ b/src/Demultiplexer/DemultiplexerBase.tpp
@@ -26,7 +26,7 @@ void DemultiplexerBase<Derived>::removeWriteEvent(int fd) {
 }
 
 template <typename Derived>
-TypeEvent	DemultiplexerBase<Derived>::getEventType(int idx) {
+EnumEvent	DemultiplexerBase<Derived>::getEventType(int idx) {
 	return static_cast<Derived&>(*this).getEventTypeImpl(idx);
 }
 

--- a/src/Demultiplexer/KqueueDemultiplexer.cpp
+++ b/src/Demultiplexer/KqueueDemultiplexer.cpp
@@ -3,72 +3,94 @@
 #include <sys/event.h>
 #include <unistd.h>
 
-KqueueDemultiplexer::KqueueDemultiplexer(std::set<int>& listenFds) : eventList_(MAX_EVENT){
-	kq_ = kqueue();
+// 생성자: kqueue를 생성하고, 리스닝 소켓들을 이벤트 감지 목록에 추가
+KqueueDemultiplexer::KqueueDemultiplexer(std::set<int>& listenFds) : eventList_(MAX_EVENT) {
+	kq_ = kqueue(); // kqueue 인스턴스 생성
 	if (kq_ == -1) {
-		perror("kqueue creation failed");
+		throw std::runtime_error("kqueue creation failed"); // kqueue 생성 실패 시 예외 발생
 	}
 
+	// 리스닝 소켓을 kqueue에 등록
 	std::set<int>::const_iterator it;
 	for (it = listenFds.begin(); it != listenFds.end(); ++it) {
 		addSocketImpl(*it);
 	}
 }
 
+// 소멸자: kqueue 파일 디스크립터 닫기
 KqueueDemultiplexer::~KqueueDemultiplexer() {
 	close(kq_);
 }
 
-int		KqueueDemultiplexer::waitForEventImpl() {
-	int numEvents = kevent(kq_, changedEvents_.data(), changedEvents_.size(), eventList_.data(), MAX_EVENT, nullptr);
-	changedEvents_.clear(); 
-	return numEvents;
+// 이벤트를 대기하는 함수 (kevent 호출)
+int KqueueDemultiplexer::waitForEventImpl() {
+	// 변경된 이벤트가 없으면(numChanges == 0) NULL 전달
+	int numChanges = changedEvents_.size();
+	const struct kevent* changedEvents = numChanges ? &changedEvents_[0] : NULL;
+
+	// kevent 호출: 이벤트 감지
+	// 반환값 : 감지된 이벤트 개수
+	numEvents_ = kevent(kq_, changedEvents, numChanges, &eventList_[0], MAX_EVENT, nullptr);
+	changedEvents_.clear(); // 변경된 이벤트 목록 초기화
+
+	return numEvents_;
 }
 
-void	KqueueDemultiplexer::addSocketImpl(int fd) {
+// 소켓을 kqueue에 등록 (읽기 이벤트 및 예외 이벤트 추가)
+void KqueueDemultiplexer::addSocketImpl(int fd) {
 	struct kevent changes[2];
 
-	EV_SET(&changes[0], fd, EVFILT_READ, EV_ADD, 0, 0, nullptr);
-	EV_SET(&changes[1], fd, EVFILT_EXCEPT, EV_ADD, 0, 0, nullptr);
-	changedEvents_.insert(changedEvents_.end(), changes, changes + 2);
+	EV_SET(&changes[0], fd, EVFILT_READ, EV_ADD, 0, 0, nullptr);  // 읽기 이벤트 추가
+	EV_SET(&changes[1], fd, EVFILT_EXCEPT, EV_ADD, 0, 0, nullptr); // 예외 이벤트 추가
+	changedEvents_.insert(changedEvents_.end(), changes, changes + 2); // 변경 이벤트 목록에 추가
 }
 
-void	KqueueDemultiplexer::removeSocketImpl(int fd) {
+// 소켓을 kqueue에서 제거 (읽기, 예외, 쓰기 이벤트 삭제)
+void KqueueDemultiplexer::removeSocketImpl(int fd) {
 	struct kevent changes[3];
 
-	EV_SET(&changes[0], fd, EVFILT_READ, EV_DELETE, 0, 0, nullptr);
-	EV_SET(&changes[1], fd, EVFILT_EXCEPT, EV_DELETE, 0, 0, nullptr);
-	EV_SET(&changes[2], fd, EVFILT_WRITE, EV_DELETE, 0, 0, nullptr);
+	EV_SET(&changes[0], fd, EVFILT_READ, EV_DELETE, 0, 0, nullptr);   // 읽기 이벤트 제거
+	EV_SET(&changes[1], fd, EVFILT_EXCEPT, EV_DELETE, 0, 0, nullptr); // 예외 이벤트 제거
+	EV_SET(&changes[2], fd, EVFILT_WRITE, EV_DELETE, 0, 0, nullptr);  // 쓰기 이벤트 제거
 	changedEvents_.insert(changedEvents_.end(), changes, changes + 3);
 }
 
-void	KqueueDemultiplexer::addWriteEventImpl(int fd) {
+// 쓰기 이벤트를 추가 (fd가 쓰기 가능할 때 감지)
+void KqueueDemultiplexer::addWriteEventImpl(int fd) {
 	struct kevent change;
 
 	EV_SET(&change, fd, EVFILT_WRITE, EV_ADD, 0, 0, nullptr);
 	changedEvents_.push_back(change);
 }
 
-void	KqueueDemultiplexer::removeWriteEventImpl(int fd) {
+// 쓰기 이벤트를 제거
+void KqueueDemultiplexer::removeWriteEventImpl(int fd) {
 	struct kevent change;
 	
 	EV_SET(&change, fd, EVFILT_WRITE, EV_DELETE, 0, 0, nullptr);
 	changedEvents_.push_back(change);
 }
 
-EnumEvent	KqueueDemultiplexer::getEventTypeImpl(int idx) {
-	if (eventList_[idx].filter == EVFILT_EXCEPT) {
-		return EXCEPTION_EVENT;
+// 특정 이벤트의 타입을 반환
+EnumEvent KqueueDemultiplexer::getEventTypeImpl(int idx) {
+	if (idx < numEvents_) { // 유효한 인덱스인지 확인
+		if (eventList_[idx].filter == EVFILT_EXCEPT) {
+			return EXCEPTION_EVENT; // 예외 이벤트
+		}
+		if (eventList_[idx].filter == EVFILT_READ) {
+			return READ_EVENT; // 읽기 이벤트
+		}
+		if (eventList_[idx].filter == EVFILT_WRITE) {
+			return WRITE_EVENT; // 쓰기 이벤트
+		}
 	}
-	if (eventList_[idx].filter == EVFILT_READ) {
-		return READ_EVENT;
-	}
-	if (eventList_[idx].filter == EVFILT_WRITE) {
-		return WRITE_EVENT;
-	}
-	return UNKNOWN_EVENT;
+	return UNKNOWN_EVENT; // 알 수 없는 이벤트
 }
 
+// 이벤트 목록에서 해당 인덱스의 파일 디스크립터 반환
 int KqueueDemultiplexer::getSocketFdImpl(int idx) {
-	return eventList_[idx].ident;
+	if (idx < numEvents_) { // 유효한 인덱스인지 확인
+		return eventList_[idx].ident; // 해당 이벤트의 fd 반환
+	}
+	return -1; // 유효하지 않은 경우 -1 반환
 }

--- a/src/Demultiplexer/KqueueDemultiplexer.cpp
+++ b/src/Demultiplexer/KqueueDemultiplexer.cpp
@@ -1,4 +1,7 @@
 #include "KqueueDemultiplexer.hpp"
+#include <iostream>
+#include <sys/event.h>
+#include <unistd.h>
 
 KqueueDemultiplexer::KqueueDemultiplexer(std::set<int>& listenFds) : eventList_(MAX_EVENT){
 	kq_ = kqueue();
@@ -53,7 +56,7 @@ void	KqueueDemultiplexer::removeWriteEventImpl(int fd) {
 	changedEvents_.push_back(change);
 }
 
-TypeEvent	KqueueDemultiplexer::getEventTypeImpl(int idx) {
+EnumEvent	KqueueDemultiplexer::getEventTypeImpl(int idx) {
 	if (eventList_[idx].filter == EVFILT_EXCEPT) {
 		return EXCEPTION_EVENT;
 	}

--- a/src/Demultiplexer/KqueueDemultiplexer.hpp
+++ b/src/Demultiplexer/KqueueDemultiplexer.hpp
@@ -4,11 +4,8 @@
 #ifdef __APPLE__
 
 #include "DemultiplexerBase.hpp"
-#include <iostream>
 #include <vector>
 #include <set>
-#include <sys/event.h>
-#include <unistd.h>
 
 class KqueueDemultiplexer : public DemultiplexerBase<KqueueDemultiplexer> {
 	public:
@@ -20,7 +17,7 @@ class KqueueDemultiplexer : public DemultiplexerBase<KqueueDemultiplexer> {
 		void		addWriteEventImpl(int fd);
 		void		removeWriteEventImpl(int fd);
 		int			getSocketFdImpl(int idx);
-		TypeEvent	getEventTypeImpl(int idx);
+		EnumEvent	getEventTypeImpl(int idx);
 	
 	
 	private:

--- a/src/Demultiplexer/KqueueDemultiplexer.hpp
+++ b/src/Demultiplexer/KqueueDemultiplexer.hpp
@@ -22,6 +22,7 @@ class KqueueDemultiplexer : public DemultiplexerBase<KqueueDemultiplexer> {
 	
 	private:
 		int							kq_;
+		in_addr_t					numEvents_;
 		std::vector<struct kevent>	eventList_;
 		std::vector<struct kevent>	changedEvents_;
 	

--- a/src/Demultiplexer/KqueueDemultiplexer.hpp
+++ b/src/Demultiplexer/KqueueDemultiplexer.hpp
@@ -22,7 +22,7 @@ class KqueueDemultiplexer : public DemultiplexerBase<KqueueDemultiplexer> {
 	
 	private:
 		int							kq_;
-		in_addr_t					numEvents_;
+		int							numEvents_;
 		std::vector<struct kevent>	eventList_;
 		std::vector<struct kevent>	changedEvents_;
 	

--- a/src/include/commonEnums.hpp
+++ b/src/include/commonEnums.hpp
@@ -13,7 +13,8 @@ typedef enum EnumSessionStatus {
 enum EnumEvent {
 	READ_EVENT,
 	WRITE_EVENT,
-	EXCEPTION_EVENT
+	EXCEPTION_EVENT,
+	UNKNOWN_EVENT
 };
 
 #endif


### PR DESCRIPTION
✅ **테스트 통과**

## 변경 사항
### 1. 인덱스 유효성 검사 (KqueueDemultiplexer.{cpp,hpp})
: getEventType(int idx), getSocketFd(int idx) implements 구현시 
인덱스 접근 전 유효성 검사 실시 및 예외 처리 기능 추가. 
유효 범위 내에 있는지 판별을 위해, 기존 메소드 내부에서 일회성으로 선언했던 이벤트 개수를 (int)numEvents_ 멤버변수에 저장해 관리. 

### 2. 벡터 주소 접근 방법 수정 (KqueueDemultiplexer.cpp)
기존 std::vec.data()가 c++98에서 지원되지 않아 직접 포인터로 접근하는 방식으로 변경.
이때 빈 벡터일 경우 &vec[0]과 같이 접근 시 에러가 발생하므로
changedEvents_ 벡터의 사이즈를 근거로 하여 NULL 혹은 벡터의 주소를 넘겨주도록 함.

### 3. DemultiplexerBase.tpp 내 생성자 및 소멸자 명시
구현 내용이 없으면 컴파일 에러 발생하므로 내용 추가

### 4. 기타
- enum 컨벤션 적용
- commonEnums.hpp EnumEvent 내 UNKNOWN_EVENT 추가
- 인클루드 위치 변경으로 의존성 개선
- #define 매크로를 static const int로 변경하여 타입 안정성 보장