### PR TITLE
feat: RequestParser 파싱과정에 GlobalConfig 사용 로직 추가

### DIFF
--- a/src/ClientSession/ClientSession.cpp
+++ b/src/ClientSession/ClientSession.cpp
@@ -65,9 +65,9 @@ EnumSesStatus ClientSession::implementReqMsg(RequestParser &parser, const std::s
 		this->reqMsg_ = new RequestMessage();
 	
 	if (this->config_ != NULL)
-		parser.setBodyMaxLength(this->config_->clientMaxBodySize_);
+		parser.setConfigBodyLength(this->config_->clientMaxBodySize_.value());
 	this->errorStatusCode_ = parser.parse(readData, this->readBuffer_, *this->reqMsg_);
-	if (this->reqMsg_->getStatus == REQ_HEADER_CRLF) {
+	if (this->reqMsg_->getStatus() == REQ_HEADER_CRLF) {
 		const GlobalConfig &globalConfig = GlobalConfig::getInstance();
 		this->config_ = globalConfig.findRequestConfig(this->listenFd_, this->reqMsg_->getMetaHost(), this->reqMsg_->getTargetURI());
 	}

--- a/src/ClientSession/ClientSession.cpp
+++ b/src/ClientSession/ClientSession.cpp
@@ -70,6 +70,10 @@ EnumSesStatus ClientSession::implementReqMsg(RequestParser &parser, const std::s
 	if (this->reqMsg_->getStatus() == REQ_HEADER_CRLF) {
 		const GlobalConfig &globalConfig = GlobalConfig::getInstance();
 		this->config_ = globalConfig.findRequestConfig(this->listenFd_, this->reqMsg_->getMetaHost(), this->reqMsg_->getTargetURI());
+		if (this->reqMsg_->getMetaHost().empty()) {
+			this->errorStatusCode_ = 400;
+			return REQUEST_ERROR;
+		}
 	}
 	if (this->errorStatusCode_ != NONE_STATUS_CODE)
 		return REQUEST_ERROR;

--- a/src/ClientSession/ClientSession.cpp
+++ b/src/ClientSession/ClientSession.cpp
@@ -64,8 +64,13 @@ EnumSesStatus ClientSession::implementReqMsg(RequestParser &parser, const std::s
 	if (this->reqMsg_ == NULL)
 		this->reqMsg_ = new RequestMessage();
 	
-	//parser.setBodyMaxLength(this->config_);
+	if (this->config_ != NULL)
+		parser.setBodyMaxLength(this->config_->clientMaxBodySize_);
 	this->errorStatusCode_ = parser.parse(readData, this->readBuffer_, *this->reqMsg_);
+	if (this->reqMsg_->getStatus == REQ_HEADER_CRLF) {
+		const GlobalConfig &globalConfig = GlobalConfig::getInstance();
+		this->config_ = globalConfig.findRequestConfig(this->listenFd_, this->reqMsg_->getMetaHost(), this->reqMsg_->getTargetURI());
+	}
 	if (this->errorStatusCode_ != NONE_STATUS_CODE)
 		return REQUEST_ERROR;
 	else if (this->reqMsg_->getStatus() == REQ_DONE)

--- a/src/ClientSession/ClientSession.cpp
+++ b/src/ClientSession/ClientSession.cpp
@@ -54,19 +54,24 @@ void ClientSession::setWriteBuffer(const std::string &remainData) {
 	this->writeBuffer_ = remainData;
 }
 
-//Optional<size_t> ClientSession::getConfBodyMax() const {
-//	if (this->config_ == NULL)
-//		return Optional<size_t>();
-//	return this->config_->clientMaxBodySize_;
-//}
-
+// EventHandler::recvRequest에서 호출되어 요청데이터를 파싱하고 결과를 판단하는 함수
+// parser: EventHandler가 들고있는 주요로직객체중 하나
+// readData: recv()함수에서 새로 읽어들인 요청 데이터
 EnumSesStatus ClientSession::implementReqMsg(RequestParser &parser, const std::string &readData) {
+	// 새로운 요청일 때, RequestMessage 동적할당
 	if (this->reqMsg_ == NULL)
-		this->reqMsg_ = new RequestMessage();
-	
+		this->reqMsg_ = new RequestMessage();// 이후 요청처리(handler&builder) 완료 후, delete 필요
+
+	// 해당 ClientSession의 RequestMessage를 파싱하기 전에 Body의 최대 길이를 설정
 	if (this->config_ != NULL)
 		parser.setConfigBodyLength(this->config_->clientMaxBodySize_.value());
+	else
+		parser.setConfigBodyLength(BODY_MAX_LENGTH);
+
+	// 이전에 버퍼 저장해놓은 데이터와 새로운 요청 데이터를 가지고 파싱
 	this->errorStatusCode_ = parser.parse(readData, this->readBuffer_, *this->reqMsg_);
+
+	// field-line까지 다 읽은 후, 요청메시지에 맞는 RequestConfig를 설정하고 Host헤더필드 유무를 검증함
 	if (this->reqMsg_->getStatus() == REQ_HEADER_CRLF) {
 		const GlobalConfig &globalConfig = GlobalConfig::getInstance();
 		this->config_ = globalConfig.findRequestConfig(this->listenFd_, this->reqMsg_->getMetaHost(), this->reqMsg_->getTargetURI());
@@ -74,7 +79,14 @@ EnumSesStatus ClientSession::implementReqMsg(RequestParser &parser, const std::s
 			this->errorStatusCode_ = 400;
 			return REQUEST_ERROR;
 		}
+		if (this->reqMsg_->getMetaContentLength() == 0
+		&&  this->reqMsg_->getMetaTransferEncoding() == NONE_ENCODING) {
+			this->reqMsg_->setStatus(REQ_DONE);
+			return READ_COMPLETE;
+		}
 	}
+
+	// 파싱이 끝나고 나서, 에러 status code와 RequestMessage의 상태를 점검함
 	if (this->errorStatusCode_ != NONE_STATUS_CODE)
 		return REQUEST_ERROR;
 	else if (this->reqMsg_->getStatus() == REQ_DONE)

--- a/src/ClientSession/ClientSession.hpp
+++ b/src/ClientSession/ClientSession.hpp
@@ -31,7 +31,7 @@ class ClientSession {
 		int						clientFd_;
 		EnumSesStatus			status_;
 		RequestMessage			*reqMsg_;
-		RequestConfig			*config_;
+		const RequestConfig		*config_;
 		std::string				readBuffer_;
 		std::string				writeBuffer_;
 };

--- a/src/ClientSession/ClientSession.hpp
+++ b/src/ClientSession/ClientSession.hpp
@@ -23,7 +23,6 @@ class ClientSession {
 		void					setReadBuffer(const std::string &remainData);
 		void					setWriteBuffer(const std::string &remainData);
 		
-		//Optional<size_t>	getConfBodyMax() const;
 		EnumSesStatus			implementReqMsg(RequestParser &parser, const std::string &readData);
 
 	private:

--- a/src/RequestParser/RequestParser.cpp
+++ b/src/RequestParser/RequestParser.cpp
@@ -4,6 +4,7 @@
 #include <stdexcept>
 #include <sstream>
 
+//Body크기에 제한 없이 테스트하고 싶은 경우, BODY_MAX_LENGTH대신 std::numeric_limits을 사용할 수 있음
 RequestParser::RequestParser() : oneLineMaxLength_(ONELINE_MAX_LENGTH), uriMaxLength_(URI_MAX_LENGTH), bodyMaxLength_(BODY_MAX_LENGTH) {}
 RequestParser::~RequestParser() {}
 

--- a/src/RequestParser/RequestParser.hpp
+++ b/src/RequestParser/RequestParser.hpp
@@ -5,6 +5,7 @@
 
 #define ONELINE_MAX_LENGTH	8190//8KB - 2bytes(\r\n)
 #define URI_MAX_LENGTH		2048//2KB
+#define BODY_MAX_LENGTH		1048576//1MB
 
 #define NONE_STATUS_CODE	0
 
@@ -14,12 +15,12 @@ class RequestParser {
 		~RequestParser();
 
 		int					parse(const std::string &readData, std::string &readBuffer, RequestMessage &reqMsg);
-		//void				setBodyMaxLength(size_t length);
+		void				setBodyMaxLength(size_t length);
 
 	private:
 		size_t				oneLineMaxLength_;
 		size_t				uriMaxLength_;
-		//Optional<size_t>	bodyMaxLength_;//Client마다 바뀌는 설정 값
+		size_t				bodyMaxLength_;//Client마다 바뀌는 설정 값
 		
 		int					handleOneLine(const std::string &line, RequestMessage &reqMsg);
 		EnumReqStatus		handleCRLFLine(const EnumReqStatus &curStatus);

--- a/src/RequestParser/RequestParser.hpp
+++ b/src/RequestParser/RequestParser.hpp
@@ -15,7 +15,7 @@ class RequestParser {
 		~RequestParser();
 
 		int					parse(const std::string &readData, std::string &readBuffer, RequestMessage &reqMsg);
-		void				setBodyMaxLength(size_t length);
+		void				setConfigBodyLength(size_t length);
 
 	private:
 		size_t				oneLineMaxLength_;


### PR DESCRIPTION
## 구현 내용
### 1. ClientSession의 implementReqMsg()에서 요청 파싱 과정 개선 및 설정값 반영
- ClientSession:: 로직내에 config를 설정하는 로직 추가
- RequestParser를 호출 시, Config가 존재하면 clientMaxBodySize를 넘겨주고, 존재하지 않는 경우에는 BODY_MAX_LENGTH(기본 1MB)를 설정하는 로직 추가
- header field들을 다 읽고난후, 처리 과정 추가
     - 요청 헤더 필드(Host) 존재 검증
     - Content-Length가 0이거나 Transfer-Encoding이 없으면 RequestMessage 완료 처리(REQ_DONE)

### 2. RequestParser에서 Config의 Body 사이즈 제한 로직 추가
- RequestParser에 setConfigBodyLength() 메서드를 추가하여 Config에서 넘어오는 clientMaxBodySize 값을 반영
- Body가 설정된 최대 길이를 초과할 경우, 413(Request Entity Too Large) 에러 코드를 반환하도록 구현

## 기타 변경 사항
### 주석 추가
- ClientSession 및 RequestParser의 메서드에 대한 주석을 보강
### 버그 수정
- 요청 메시지 테스트 후 발견된 문제를 수정
    - readData와 readBuffer의 합칠때 순서 오류
    - ClientSession의 RequestConfig*를 const RequestConfig*로 변경하여 Config 참조 안정성을 개선
    - Body 파싱 시, 남은 데이터(readBuffer) 처리 로직을 보강했습니다.