### PR TITLE
feat: IPv6 주소 지원 제거

### DIFF
--- a/src/ConfigParser/parse_server_block.cpp
+++ b/src/ConfigParser/parse_server_block.cpp
@@ -1,73 +1,73 @@
 #include "ConfigParser.hpp"
 
 namespace {
-	// IPv6 주소를 파싱하는 함수
-	// hostPortToken: 파싱할 문자열
-	// tokenIterator: 문자열 내의 현재 위치 iterator
-	// host: 파싱된 호스트(IPv6 주소)를 저장할 변수
-	void parseIPv6Address(std::string& hostPortToken, std::string::iterator& tokenIterator, std::string& host) {
-		// 토큰이 '['로 시작하는지 확인
-		if (tokenIterator == hostPortToken.end() || *tokenIterator != '[') {
-			throw std::runtime_error("Invalid IPv6 address: missing opening '['");
-		}
-		++tokenIterator; // '[' 건너뛰기
+	// // IPv6 주소를 파싱하는 함수
+	// // hostPortToken: 파싱할 문자열
+	// // tokenIterator: 문자열 내의 현재 위치 iterator
+	// // host: 파싱된 호스트(IPv6 주소)를 저장할 변수
+	// void parseIPv6Address(std::string& hostPortToken, std::string::iterator& tokenIterator, std::string& host) {
+	// 	// 토큰이 '['로 시작하는지 확인
+	// 	if (tokenIterator == hostPortToken.end() || *tokenIterator != '[') {
+	// 		throw std::runtime_error("Invalid IPv6 address: missing opening '['");
+	// 	}
+	// 	++tokenIterator; // '[' 건너뛰기
 
-		std::string parsedAddress;
-		// IPv6 주소는 정확히 8개의 hextet(16진수 묶음)으로 구성되어야 함
-		for (int i = 0; i < 8; ++i) {
-			std::string hextet;
-			int count = 0;
-			// 각 hextet은 최대 4자리의 16진수로 구성됨
-			while (tokenIterator != hostPortToken.end() && count < 4 && std::isxdigit(*tokenIterator)) {
-				hextet.push_back(*tokenIterator);
-				++tokenIterator;
-				++count;
-			}
-			// 각 hextet은 최소 한 자리 이상의 16진수가 있어야 함
-			if (hextet.empty()) {
-				throw std::runtime_error("Invalid IPv6 address: expected hex digits in hextet");
-			}
-			// 4자리 초과의 16진수는 오류
-			if (tokenIterator != hostPortToken.end() && std::isxdigit(*tokenIterator)) {
-				throw std::runtime_error("Invalid IPv6 address: hextet exceeds 4 hex digits");
-			}
+	// 	std::string parsedAddress;
+	// 	// IPv6 주소는 정확히 8개의 hextet(16진수 묶음)으로 구성되어야 함
+	// 	for (int i = 0; i < 8; ++i) {
+	// 		std::string hextet;
+	// 		int count = 0;
+	// 		// 각 hextet은 최대 4자리의 16진수로 구성됨
+	// 		while (tokenIterator != hostPortToken.end() && count < 4 && std::isxdigit(*tokenIterator)) {
+	// 			hextet.push_back(*tokenIterator);
+	// 			++tokenIterator;
+	// 			++count;
+	// 		}
+	// 		// 각 hextet은 최소 한 자리 이상의 16진수가 있어야 함
+	// 		if (hextet.empty()) {
+	// 			throw std::runtime_error("Invalid IPv6 address: expected hex digits in hextet");
+	// 		}
+	// 		// 4자리 초과의 16진수는 오류
+	// 		if (tokenIterator != hostPortToken.end() && std::isxdigit(*tokenIterator)) {
+	// 			throw std::runtime_error("Invalid IPv6 address: hextet exceeds 4 hex digits");
+	// 		}
 
-			// hextet에서 선행하는 0을 제거
-			size_t nonZeroPos = 0;
-			while (nonZeroPos < hextet.size() && hextet[nonZeroPos] == '0') {
-				++nonZeroPos;
-			}
-			std::string stripped = (nonZeroPos == hextet.size()) ? "0" : hextet.substr(nonZeroPos);
+	// 		// hextet에서 선행하는 0을 제거
+	// 		size_t nonZeroPos = 0;
+	// 		while (nonZeroPos < hextet.size() && hextet[nonZeroPos] == '0') {
+	// 			++nonZeroPos;
+	// 		}
+	// 		std::string stripped = (nonZeroPos == hextet.size()) ? "0" : hextet.substr(nonZeroPos);
 
-			// hextet을 소문자로 변환
-			for (size_t j = 0; j < stripped.size(); ++j) {
-				stripped[j] = std::tolower(stripped[j]);
-			}
+	// 		// hextet을 소문자로 변환
+	// 		for (size_t j = 0; j < stripped.size(); ++j) {
+	// 			stripped[j] = std::tolower(stripped[j]);
+	// 		}
 
-			// 처리된 hextet을 결과 문자열에 추가 (필요 시 ':' 구분자 추가)
-			if (!parsedAddress.empty()) {
-				parsedAddress.push_back(':');
-			}
-			parsedAddress.append(stripped);
+	// 		// 처리된 hextet을 결과 문자열에 추가 (필요 시 ':' 구분자 추가)
+	// 		if (!parsedAddress.empty()) {
+	// 			parsedAddress.push_back(':');
+	// 		}
+	// 		parsedAddress.append(stripped);
 
-			// 마지막 hextet을 제외하고는 ':' 구분자가 있어야 함
-			if (i < 7) {
-				if (tokenIterator == hostPortToken.end() || *tokenIterator != ':') {
-					throw std::runtime_error("Invalid IPv6 address: expected ':' delimiter between hextets");
-				}
-				++tokenIterator; // ':' 건너뛰기
-			}
-		}
+	// 		// 마지막 hextet을 제외하고는 ':' 구분자가 있어야 함
+	// 		if (i < 7) {
+	// 			if (tokenIterator == hostPortToken.end() || *tokenIterator != ':') {
+	// 				throw std::runtime_error("Invalid IPv6 address: expected ':' delimiter between hextets");
+	// 			}
+	// 			++tokenIterator; // ':' 건너뛰기
+	// 		}
+	// 	}
 
-		// 8개의 hextet 이후에는 닫는 대괄호 ']'가 있어야 함
-		if (tokenIterator == hostPortToken.end() || *tokenIterator != ']') {
-			throw std::runtime_error("Invalid IPv6 address: missing closing ']'");
-		}
-		++tokenIterator; // ']' 건너뛰기
+	// 	// 8개의 hextet 이후에는 닫는 대괄호 ']'가 있어야 함
+	// 	if (tokenIterator == hostPortToken.end() || *tokenIterator != ']') {
+	// 		throw std::runtime_error("Invalid IPv6 address: missing closing ']'");
+	// 	}
+	// 	++tokenIterator; // ']' 건너뛰기
 
-		// 처리된 IPv6 주소를 host 변수에 저장
-		host = parsedAddress;
-	}
+	// 	// 처리된 IPv6 주소를 host 변수에 저장
+	// 	host = parsedAddress;
+	// }
 
 	// IPv4 주소를 파싱하는 함수
 	// hostPortToken: 파싱할 문자열
@@ -167,7 +167,8 @@ void ConfigParser::parseHostPort(std::ifstream& configFile, std::string& host, u
 	if (!utils::all_of(token.begin(), token.end(), ::isdigit)) {
 		if (*tokenIterator == '[') {
 			// IPv6 주소인 경우
-			parseIPv6Address(token, tokenIterator, host);
+			// parseIPv6Address(token, tokenIterator, host);
+			throw std::runtime_error("IPv6 address is not supported");
 		}
 		else {
 			// IPv4 주소인 경우

--- a/src/ServerManager/ServerManager.cpp
+++ b/src/ServerManager/ServerManager.cpp
@@ -5,126 +5,178 @@
 #include <map>
 #include <utility>
 #include <sys/socket.h>
+#include <netdb.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <unistd.h>
 #include <fcntl.h>
 #include <cstring>
 
-// 프로그램을 종료할 때 소켓을 닫기 위해 소멸자를 사용합니다.
+// 프로그램 종료 시, 열려있는 소켓들을 닫기 위한 소멸자입니다.
 ServerManager::~ServerManager() {
+    // listenFds_에 저장된 모든 소켓 파일 디스크립터에 대해 close()를 호출합니다.
     for (std::set<int>::iterator it = listenFds_.begin(); it != listenFds_.end(); ++it) {
         close(*it);
     }
+    // 소켓 파일 디스크립터 집합을 비웁니다.
     listenFds_.clear();
 }
 
-// 서버 매니저를 초기화하고 수신 소켓을 설정합니다.
+// 서버 매니저를 초기화하고 수신 소켓을 설정하는 함수입니다.
 void ServerManager::setupListeningSockets() {
-	// 전역 설정을 가져와서 수정할 수 있도록 const_cast를 사용합니다.
-	GlobalConfig& globalConfig = const_cast<GlobalConfig&>(GlobalConfig::getInstance());
-    // 주소와 포트를 소켓 파일 디스크립터에 매핑하는 맵을 생성합니다.
+    // 전역 설정(GlobalConfig) 인스턴스를 가져와 수정할 수 있도록 const_cast를 사용합니다.
+    GlobalConfig &globalConfig = const_cast<GlobalConfig&>(GlobalConfig::getInstance());
+    // (호스트, 포트) 쌍을 키로, 소켓 파일 디스크립터를 값으로 하는 맵을 생성합니다.
     std::map<std::pair<std::string, int>, int> addressToSocket;
 
-    // 전역 설정에 정의된 각 가상 서버 구성을 반복합니다.
+    // 전역 설정에 등록된 각 가상 서버 구성에 대해 반복합니다.
     for (size_t i = 0; i < globalConfig.servers_.size(); ++i) {
-        ServerConfig& server = globalConfig.servers_[i];
-
-        // 이 서버의 호스트와 포트를 가져옵니다.
+        ServerConfig &server = globalConfig.servers_[i];
+        // 현재 서버의 호스트와 포트 정보를 키로 생성합니다.
         std::pair<std::string, int> key = std::make_pair(server.host_, server.port_);
 
         int sockFd;
-        // 이 호스트/포트 조합에 대한 소켓이 이미 생성되었는지 확인합니다.
+        // 해당 호스트/포트 조합에 대해 이미 소켓이 생성되었는지 확인합니다.
         if (addressToSocket.find(key) != addressToSocket.end()) {
             sockFd = addressToSocket[key];
         } else {
-            // 새 TCP 소켓을 생성합니다.
-            sockFd = socket(AF_INET, SOCK_STREAM, 0);
-            if (sockFd < 0) {
-				throw std::runtime_error("Failed to create socket");
-            }
-
-            // 소켓을 논블로킹 모드로 설정합니다.
-            // 소켓의 현재 플래그를 가져옵니다.
-            int flags = fcntl(sockFd, F_GETFL, 0);
-            if (flags == -1) {
-                close(sockFd);
-                throw std::runtime_error("Failed to get socket flags");
-            }
-            // 논블로킹 작업을 위해 O_NONBLOCK 플래그를 추가합니다.
-            if (fcntl(sockFd, F_SETFL, flags | O_NONBLOCK) == -1) {
-                close(sockFd);
-                throw std::runtime_error("Failed to set socket flags");
-            }
-
-            // 로컬 주소의 재사용을 허용하도록 소켓 옵션을 설정합니다.
-            int opt = 1;
-            if (setsockopt(sockFd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)) < 0) {
-                close(sockFd);
-                throw std::runtime_error("Failed to set socket options");
-            }
-
-            // 서버의 주소를 정의하기 위해 sockaddr_in 구조체를 초기화합니다.
-            sockaddr_in addr;
-            addr.sin_family = AF_INET;                 // IPv4 사용.
-            addr.sin_port = htons(server.port_);       // 포트를 설정하며, 네트워크 바이트 순서로 변환.
-            if (server.host_ == "0.0.0.0") {
-                addr.sin_addr.s_addr = INADDR_ANY;       // 모든 사용 가능한 인터페이스에 바인딩.
-            } else {
-                // 텍스트 형태의 IP 주소를 바이너리 형태로 변환합니다.
-                if (inet_aton(server.host_.c_str(), &addr.sin_addr) == 0) {
-                    close(sockFd);
-					throw std::runtime_error("Invalid IP address");
-                }
-            }
-
-            // 지정된 IP 주소와 포트에 소켓을 바인딩합니다.
-            if (bind(sockFd, reinterpret_cast<struct sockaddr*>(&addr), sizeof(addr)) < 0) {
-                close(sockFd);
-				std::string errorMsg = "Failed to bind socket to " + server.host_ + ":" + std::to_string(server.port_) + " - " + strerror(errno);
-    			throw std::runtime_error(errorMsg);
-            }
-
-            // 소켓에서 들어오는 연결 요청을 수신하기 시작합니다.
-            if (listen(sockFd, SOMAXCONN) < 0) {
-                close(sockFd);
-                throw std::runtime_error("Failed to listen on socket");
-            }
-
-            // 중복된 소켓 생성을 방지하기 위해 새로운 소켓을 맵에 저장합니다.
+            // 새로운 TCP 소켓을 생성합니다.
+            sockFd = createListeningSocket(server);
+            // 중복 소켓 생성을 방지하기 위해 맵에 저장합니다.
             addressToSocket[key] = sockFd;
-            // 소켓을 수신 대기 파일 디스크립터 집합에 추가합니다.
+            // 생성된 소켓을 수신 대기 소켓 집합에 추가합니다.
             listenFds_.insert(sockFd);
         }
-
-        // 이 서버 구성을 해당 수신 소켓에 매핑합니다.
+        // 현재 서버 구성을 해당 수신 소켓에 매핑합니다.
         // 이를 통해 여러 서버 구성이 동일한 소켓을 공유할 수 있습니다.
         globalConfig.listenFdToServers_[sockFd].push_back(&server);
     }
 }
 
+// 새 TCP 소켓을 생성하는 함수입니다.
+int ServerManager::createListeningSocket(const ServerConfig &server)
+{
+    struct addrinfo hints, *result, *currAddr;
+    char portStr[6];
+    
+    // 주소 정보를 위한 힌트 구조체를 초기화합니다.
+    initAddrInfo(hints);
+    // 포트 번호를 문자열로 변환합니다.
+    snprintf(portStr, sizeof(portStr), "%d", server.port_);
+
+    // 서버의 호스트명과 포트 번호를 기반으로 주소 정보를 가져옵니다.
+    if (getaddrinfo(server.host_.c_str(), portStr, &hints, &result)) {
+        throw std::runtime_error(std::string("getaddrinfo: ") + gai_strerror(s));
+    }
+
+    // 얻어온 주소 정보 리스트를 순회하며 소켓 생성 및 바인딩을 시도합니다.
+    for (currAddr = result; currAddr != NULL; currAddr = currAddr->ai_next) {
+        // 소켓을 생성합니다.
+        sockFd = socket(currAddr->ai_family, currAddr->ai_socktype, currAddr->ai_protocol);
+        if (sockFd < 0)
+            continue;
+        // 소켓 옵션 설정 (주소 재사용 및 논블로킹 모드 설정)
+        if (configureSocket(sockFd)) {
+            close(sockFd);
+            continue;
+        }
+        // 소켓을 특정 주소와 포트에 바인딩합니다.
+        if (bind(sockFd, currAddr->ai_addr, currAddr->ai_addrlen) < 0) {
+            close(sockFd);
+            continue;
+        }
+        // 바인딩에 성공하면 반복문을 종료합니다.
+        break;
+    }
+    // 사용한 주소 정보 메모리를 해제합니다.
+    freeaddrinfo(result);
+    // 모든 주소에 바인딩하지 못한 경우 예외를 발생시킵니다.
+    if (currAddr == NULL) {
+        throw std::runtime_error("Failed to bind socket to " + server.host_ +
+                                 ":" + std::string(portStr));
+    }
+    // 소켓을 수신 대기 상태로 전환합니다.
+    if (listen(sockFd, SOMAXCONN) < 0) {
+        close(sockFd);
+        throw std::runtime_error("Failed to listen on socket");
+    }
+    // 생성된 소켓 파일 디스크립터를 반환합니다.
+    return sockFd;
+}
+
+// addrinfo 구조체의 힌트를 초기화하는 함수입니다.
+void ServerManager::initAddrInfo(struct addrinfo &hints) {
+    // hints 구조체의 모든 필드를 0으로 초기화합니다.
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_UNSPEC;    // IPv4와 IPv6 모두 허용
+    hints.ai_socktype = SOCK_STREAM; // TCP 스트림 소켓 사용
+    hints.ai_flags = AI_PASSIVE;     // 로컬 주소에 바인딩하기 위해 설정
+}
+
+// 소켓 옵션과 논블로킹 모드를 설정하는 함수입니다.
+int ServerManager::configureSocket(int sockFd) {
+    if (setSocketOptions(sockFd) < 0) {
+        return -1;
+    }
+    if (setNonBlocking(sockFd) < 0) {
+        return -1;
+    }
+    return 0;
+}
+
+// 소켓을 논블로킹 모드로 설정하는 함수입니다.
+int ServerManager::setNonBlocking(int sockFd) {
+    // 현재 파일 디스크립터의 플래그를 가져옵니다.
+    int flags = fcntl(sockFd, F_GETFL, 0);
+    if (flags == -1) {
+        return -1;
+    }
+    // 논블로킹 플래그를 추가하여 파일 디스크립터의 모드를 변경합니다.
+    if (fcntl(sockFd, F_SETFL, flags | O_NONBLOCK) == -1) {
+        return -1;
+    }
+    return 0;
+}
+
+// 로컬 주소 재사용을 허용하는 소켓 옵션을 설정하는 함수입니다.
+int ServerManager::setSocketOptions(int sockFd) {
+    int opt = 1;
+    // SO_REUSEADDR 옵션을 활성화하여, 소켓을 빠르게 재사용할 수 있도록 합니다.
+    if (setsockopt(sockFd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)) < 0) {
+        return -1;
+    }
+    return 0;
+}
+
+// 주어진 IP 주소가 IPv6 주소인지 확인하는 함수입니다.
+inline bool isIPv6(const std::string& ip) const {
+    struct in6_addr addr;
+    // inet_pton() 함수를 사용해 IPv6 형식의 주소인지 검사합니다.
+    return inet_pton(AF_INET6, ip.c_str(), &addr) == 1;
+}
+
 extern volatile bool globalServerRunning;
 
 // 서버를 종료해야 하는지 확인하는 함수입니다.
-bool ServerManager::isServerRunning() {
-    return globalServerRunning;
+bool ServerManager::isServerRunning() const {
+	return globalServerRunning;
 }
 
 // 디버깅을 위해 현재 수신 소켓 정보를 출력합니다.
-void ServerManager::print() {
-    std::cout << "listenFds: ";
-    for (std::set<int>::iterator it = listenFds_.begin(); it != listenFds_.end(); ++it) {
-        std::cout << *it << ", ";
-    }
-    std::cout << std::endl;
+void ServerManager::print() const {
+	std::cout << "listenFds: ";
+	for (std::set<int>::iterator it = listenFds_.begin(); it != listenFds_.end(); ++it) {
+		std::cout << *it << ", ";
+	}
+	std::cout << std::endl;
 
-    std::cout << "listenFdToServers_: " << std::endl;
-    for (std::map<int, std::vector<ServerConfig*> >::const_iterator it = GlobalConfig::getInstance().listenFdToServers_.begin();
-         it != GlobalConfig::getInstance().listenFdToServers_.end(); ++it) {
-        std::cout << "listenFd: " << it->first << std::endl;
-        for (size_t i = 0; i < it->second.size(); ++i) {
-            std::cout << "server: " << it->second[i]->host_ << ":" << it->second[i]->port_ << std::endl;
-        }
-    }
+	std::cout << "listenFdToServers_: " << std::endl;
+	for (std::map<int, std::vector<ServerConfig*> >::const_iterator it = GlobalConfig::getInstance().listenFdToServers_.begin();
+		 it != GlobalConfig::getInstance().listenFdToServers_.end(); ++it) {
+		std::cout << "listenFd: " << it->first << std::endl;
+		for (size_t i = 0; i < it->second.size(); ++i) {
+			std::cout << "server: " << it->second[i]->host_ << ":" << it->second[i]->port_ << std::endl;
+		}
+	}
 }
 

--- a/src/ServerManager/ServerManager.cpp
+++ b/src/ServerManager/ServerManager.cpp
@@ -108,9 +108,9 @@ int ServerManager::createListeningSocket(const ServerConfig &server)
 void ServerManager::initAddrInfo(struct addrinfo &hints) {
     // hints 구조체의 모든 필드를 0으로 초기화합니다.
     memset(&hints, 0, sizeof(hints));
-    hints.ai_family = AF_UNSPEC;    // IPv4와 IPv6 모두 허용
-    hints.ai_socktype = SOCK_STREAM; // TCP 스트림 소켓 사용
-    hints.ai_flags = AI_PASSIVE;     // 로컬 주소에 바인딩하기 위해 설정
+    hints.ai_family = AF_INET;			// IPv4 허용
+    hints.ai_socktype = SOCK_STREAM;	// TCP 스트림 소켓 사용
+    hints.ai_flags = AI_PASSIVE;		// 로컬 주소에 바인딩하기 위해 설정
 }
 
 // 소켓 옵션과 논블로킹 모드를 설정하는 함수입니다.
@@ -146,13 +146,6 @@ int ServerManager::setSocketOptions(int sockFd) {
         return -1;
     }
     return 0;
-}
-
-// 주어진 IP 주소가 IPv6 주소인지 확인하는 함수입니다.
-inline bool isIPv6(const std::string& ip) const {
-    struct in6_addr addr;
-    // inet_pton() 함수를 사용해 IPv6 형식의 주소인지 검사합니다.
-    return inet_pton(AF_INET6, ip.c_str(), &addr) == 1;
 }
 
 extern volatile bool globalServerRunning;

--- a/src/ServerManager/ServerManager.hpp
+++ b/src/ServerManager/ServerManager.hpp
@@ -38,8 +38,6 @@ class ServerManager {
         int setNonBlocking(int sockFd) const;
         // 소켓 옵션을 설정합니다.
         int setSocketOptions(int sockFd) const;
-		// IPv6 주소인지 확인합니다.
-		inline bool isIPv6(const std::string& ip) const;
 
 		// run() 함수에서 사용되는 함수들
         // 주어진 파일 디스크립터(fd)가 수신 소켓인지 판단하는 함수

--- a/src/ServerManager/ServerManager.hpp
+++ b/src/ServerManager/ServerManager.hpp
@@ -1,7 +1,6 @@
 #ifndef SERVER_MANAGER_HPP
 #define SERVER_MANAGER_HPP
 
-#include <set>
 #include "../GlobalConfig/GlobalConfig.hpp"
 #include "../Demultiplexer/KqueueDemultiplexer.hpp"
 #include "../TimeoutHandler/TimeoutHandler.hpp"
@@ -9,44 +8,48 @@
 #include "../ClientManager/ClientManager.hpp"
 #include "../include/commonEnums.hpp"
 
+#include <set>
+
 class ServerManager {
-	public:
-		~ServerManager(); // 소멸자: 객체 소멸 시 리소스 정리 등 필요한 작업 수행
+    public:
+        ~ServerManager();
 
-		void setupListeningSockets(); 
         // 수신 소켓 설정 함수: 클라이언트 연결 수신을 위한 소켓들을 초기화하고 바인딩하는 역할
-
-		void run();
+        void setupListeningSockets(); 
         // 서버 실행 함수: 메인 이벤트 루프를 돌며 클라이언트 연결 및 데이터 송수신, 타임아웃 관리 등을 수행
-
-		bool isServerRunning();
+        void run();
         // 서버 실행 여부 확인 함수: 서버가 정상적으로 실행 중인지 판단
+        bool isServerRunning();
+		// 디버깅을 위한 현재 수신 소켓 정보 출력 함수
+		void print() const;
 
-	private:
-		std::set<int> listenFds_; 
+    private:
         // 수신 소켓 파일 디스크립터 집합: 서버가 수신 대기 중인 소켓들을 저장
+        std::set<int> listenFds_; 
 
-		// bool listenFdStatus_; // signal 핸들링과 관련 있으므로 논의 필요
+		// setupListeningSockets() 함수에서 사용되는 함수들
+		// 새 TCP 소켓을 생성합니다.
+        int createListeningSocket(const ServerConfig &server) const;
+        // 주소 정보를 초기화합니다.
+        void initAddrInfo(struct addrinfo &hints) const;
+        // 소켓을 구성합니다.
+        int configureSocket(int sockFd) const;
+        // 소켓을 논블로킹 모드로 설정합니다.
+        int setNonBlocking(int sockFd) const;
+        // 소켓 옵션을 설정합니다.
+        int setSocketOptions(int sockFd) const;
+		// IPv6 주소인지 확인합니다.
+		inline bool isIPv6(const std::string& ip) const;
 
-		bool isListeningSocket(int fd);
+		// run() 함수에서 사용되는 함수들
         // 주어진 파일 디스크립터(fd)가 수신 소켓인지 판단하는 함수
-
-		void addClientInfo(int listenFd, int clientFd, ClientManager& clientManager, Demultiplexer& reactor, TimeoutHandler& timeoutHandler);
+        bool isListeningSocket(int fd);
         // 새로운 클라이언트 연결 정보를 추가하는 함수
-        // - ClientManager: 클라이언트 세션 관리
-        // - Demultiplexer: 이벤트 루프에 클라이언트 소켓 등록
-        // - TimeoutHandler: 클라이언트 타임아웃 관리 추가
-
-		void removeClientInfo(int clientFd, ClientManager& clientManager, Demultiplexer& reactor, TimeoutHandler& timeoutHandler);
+        void addClientInfo(int listenFd, int clientFd, ClientManager& clientManager, Demultiplexer& reactor, TimeoutHandler& timeoutHandler);
         // 기존 클라이언트 연결 정보를 제거하는 함수
-        // - ClientManager: 클라이언트 세션 제거
-        // - Demultiplexer: 이벤트 루프에서 클라이언트 소켓 제거
-        // - TimeoutHandler: 타임아웃 관리 제거
-
-		void cleanUpConnections(ClientManager& clientManager, EventHandler& eventHandler);
+        void removeClientInfo(int clientFd, ClientManager& clientManager, Demultiplexer& reactor, TimeoutHandler& timeoutHandler);
         // 서버 종료 시, 모든 클라이언트에 종료 응답 전송 및 연결 정리 함수
-        // - ClientManager: 모든 클라이언트 세션 접근
-        // - EventHandler: 클라이언트에게 서버 종료 알림 전송
+        void cleanUpConnections(ClientManager& clientManager, EventHandler& eventHandler);
 };
 
 #endif


### PR DESCRIPTION
- ServerManager::setupListeningSockets를 작은 함수들로 리팩토링
- IPv6 주소 지원을 제거하고, IPv4 주소만 지원

이슈 번호: #65