### PR TITLE
Refactor: eventhandler

### DIFF
--- a/src/ClientManager/ClientManager.cpp
+++ b/src/ClientManager/ClientManager.cpp
@@ -14,9 +14,9 @@ ClientManager::~ClientManager() {
 }
 
 // 새로운 clientSession 생성 및 관리 목록에 추가
-void ClientManager::addClient(int listenFd, int clientFd) {
+void ClientManager::addClient(int listenFd, int clientFd, std::string clientAddr) {
 	// 중복 검사 필요 여부 고려
-	ClientSession* newClient = new ClientSession(listenFd, clientFd);
+	ClientSession* newClient = new ClientSession(listenFd, clientFd, clientAddr);
 	clientList_.insert(std::make_pair(clientFd, newClient)); // clientFd를 key로 하여 추가
 }
 

--- a/src/ClientManager/ClientManager.hpp
+++ b/src/ClientManager/ClientManager.hpp
@@ -10,7 +10,7 @@ class ClientManager {
 		typedef std::map<int, ClientSession*>	TypeClientMap;
 		ClientManager();
 		~ClientManager();
-		void					addClient(int listenFd, int clientFd);
+		void					addClient(int listenFd, int clientFd, std::string clientAddr);
 		TypeClientMap::iterator	removeClient(int fd);
 		ClientSession*			accessClientSession(int fd);
 		TypeClientMap&			accessClientSessionMap();

--- a/src/ClientSession/ClientSession.cpp
+++ b/src/ClientSession/ClientSession.cpp
@@ -1,6 +1,6 @@
 #include "ClientSession.hpp"
 
-ClientSession::ClientSession(int listenFd, int clientFd, std::string clientAddr) : status_(READ_CONTINUE), listenFd_(listenFd), clientFd_(clientFd), clientAddr_(clientAddr), reqMsg_(NULL), config_(NULL) {}
+ClientSession::ClientSession(int listenFd, int clientFd, std::string clientIP) : status_(READ_CONTINUE), listenFd_(listenFd), clientFd_(clientFd), clientIP_(clientIP), reqMsg_(NULL), config_(NULL) {}
 
 ClientSession::~ClientSession() {
 	if (this->reqMsg_ != NULL)
@@ -23,8 +23,8 @@ EnumSesStatus ClientSession::getStatus() const {
 	return this->status_;
 }
 
-std::string	ClientSession::getClientAddr() const {
-	return this->clientAddr_;
+std::string	ClientSession::getClientIP() const {
+	return this->clientIP_;
 }
 
 std::string ClientSession::getReadBuffer() const {

--- a/src/ClientSession/ClientSession.cpp
+++ b/src/ClientSession/ClientSession.cpp
@@ -1,6 +1,7 @@
 #include "ClientSession.hpp"
 
-ClientSession::ClientSession(int listenFd, int clientFd) : status_(READ_CONTINUE), listenFd_(listenFd), clientFd_(clientFd), reqMsg_(NULL), config_(NULL) {}
+ClientSession::ClientSession(int listenFd, int clientFd, std::string clientAddr) : status_(READ_CONTINUE), listenFd_(listenFd), clientFd_(clientFd), clientAddr_(clientAddr), reqMsg_(NULL), config_(NULL) {}
+
 ClientSession::~ClientSession() {
 	if (this->reqMsg_ != NULL)
 		delete this->reqMsg_;
@@ -16,6 +17,10 @@ int ClientSession::getClientFd() const {
 
 EnumSesStatus ClientSession::getStatus() const {
 	return this->status_;
+}
+
+std::string	ClientSession::getClientAddr() const {
+	return this->clientAddr_;
 }
 
 std::string ClientSession::getReadBuffer() const {

--- a/src/ClientSession/ClientSession.cpp
+++ b/src/ClientSession/ClientSession.cpp
@@ -15,6 +15,10 @@ int ClientSession::getClientFd() const {
 	return this->clientFd_;
 }
 
+int ClientSession::getErrorStatusCode() const {
+	return this->errorStatusCode_;
+}
+
 EnumSesStatus ClientSession::getStatus() const {
 	return this->status_;
 }

--- a/src/ClientSession/ClientSession.hpp
+++ b/src/ClientSession/ClientSession.hpp
@@ -7,12 +7,13 @@
 
 class ClientSession {
 	public:
-		ClientSession(int listenFd, int clientFd);
+		ClientSession(int listenFd, int clientFd, std::string clientAddr);
 		~ClientSession();
 
 		int						getListenFd() const;
 		int						getClientFd() const;
 		EnumSesStatus			getStatus() const;
+		std::string				getClientAddr() const;
 		std::string				getReadBuffer() const;
 		std::string				getWriteBuffer() const;
 		const RequestMessage	&getReqMsg() const;
@@ -34,6 +35,7 @@ class ClientSession {
 		const RequestConfig		*config_;
 		std::string				readBuffer_;
 		std::string				writeBuffer_;
+		std::string				clientAddr_;
 };
 
 #endif

--- a/src/ClientSession/ClientSession.hpp
+++ b/src/ClientSession/ClientSession.hpp
@@ -7,14 +7,14 @@
 
 class ClientSession {
 	public:
-		ClientSession(int listenFd, int clientFd, std::string clientAddr);
+		ClientSession(int listenFd, int clientFd, std::string clientIP);
 		~ClientSession();
 
 		int						getListenFd() const;
 		int						getClientFd() const;
 		int						getErrorStatusCode() const;
 		EnumSesStatus			getStatus() const;
-		std::string				getClientAddr() const;
+		std::string				getClientIP() const;
 		std::string				getReadBuffer() const;
 		std::string				getWriteBuffer() const;
 		const RequestMessage	&getReqMsg() const;
@@ -36,7 +36,7 @@ class ClientSession {
 		const RequestConfig		*config_;
 		std::string				readBuffer_;
 		std::string				writeBuffer_;
-		std::string				clientAddr_;
+		std::string				clientIP_;
 };
 
 #endif

--- a/src/ClientSession/ClientSession.hpp
+++ b/src/ClientSession/ClientSession.hpp
@@ -12,6 +12,7 @@ class ClientSession {
 
 		int						getListenFd() const;
 		int						getClientFd() const;
+		int						getErrorStatusCode() const;
 		EnumSesStatus			getStatus() const;
 		std::string				getClientAddr() const;
 		std::string				getReadBuffer() const;

--- a/src/EventHandler/EventHandler.cpp
+++ b/src/EventHandler/EventHandler.cpp
@@ -1,4 +1,6 @@
 #include "EventHandler.hpp"
+#include <arpa/inet.h>
+#include <netinet/in.h>
 
 EventHandler::EventHandler() : staticHandler_(rspBuilder_) {
 
@@ -10,15 +12,16 @@ EventHandler::~EventHandler() {
 
 // 서버 fd에서 발생한 Read 이벤트 처리
 int	EventHandler::handleServerReadEvent(int fd, ClientManager& clientManager) {
-    struct sockaddr clientAddr;
-    socklen_t addrLen = sizeof(clientAddr);
+    struct sockaddr_in  clientAddr;
+    socklen_t           addrLen = sizeof(clientAddr);
 
     int clientFd = accept(fd, (struct sockaddr*)&clientAddr, &addrLen);
     if (clientFd < 0) {
         perror("client accept error");
     }
 
-    clientManager.addClient(fd, clientFd, /*string으로 변환된 clientAddr*/);
+    std::string clientIP(inet_ntoa(clientAddr.sin_addr));
+    clientManager.addClient(fd, clientFd, clientIP);
 
     return clientFd;
 }

--- a/src/EventHandler/EventHandler.cpp
+++ b/src/EventHandler/EventHandler.cpp
@@ -25,7 +25,7 @@ int	EventHandler::handleServerReadEvent(int fd, ClientManager& clientManager) {
 
 // 클라이언트 fd에서 발생한 Read 이벤트 처리
 int	EventHandler::handleClientReadEvent(ClientSession& clientSession) {
-    int status = recvRequest(clientSession); // ! parser_넘겨줄 필요가 없음
+    int status = recvRequest(clientSession);
     //recvRequest: EventHandler의 멤버 함수
     //parser_: EventHandler의 멤버 변수
 
@@ -34,8 +34,6 @@ int	EventHandler::handleClientReadEvent(ClientSession& clientSession) {
 		std::string     responseMsg;
 
         // CGI 실행 여부 판별 및 응답 생성
-        // 일단 requestMsg와 config가 nullptr일리가 없을 것 같아서 가드를 따로 하진 않았습니다.
-        // 그치만 nullptr일리 없다면, 애초에 레퍼런스여도 되지 않을까요..??!
 		if (cgiHandler_.isCGI(requestMsg.getTargetURI())) {
 			responseMsg = cgiHandler_.handleRequest(clientSession);
 		} else {
@@ -48,7 +46,7 @@ int	EventHandler::handleClientReadEvent(ClientSession& clientSession) {
         status = sendResponse(clientSession);
     } else if (status == REQUEST_ERROR) {
         int statusCode = clientSession.getErrorStatusCode();
-        
+
         handleError(statusCode, clientSession);
     }
 

--- a/src/EventHandler/EventHandler.cpp
+++ b/src/EventHandler/EventHandler.cpp
@@ -1,8 +1,10 @@
 #include "EventHandler.hpp"
-#include <arpa/inet.h>
+#include <iostream>
+#include <sys/socket.h>
 #include <netinet/in.h>
+#include <arpa/inet.h>
 
-EventHandler::EventHandler() : staticHandler_(rspBuilder_) {
+EventHandler::EventHandler() : staticHandler_(rspBuilder_), cgiHandler_(rspBuilder_) {
 
 }
 

--- a/src/EventHandler/EventHandler.cpp
+++ b/src/EventHandler/EventHandler.cpp
@@ -4,6 +4,7 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 
+// ResponseBuilder를 인자로 하여 정적 핸들러와 CGI 핸들러를 초기화합니다.
 EventHandler::EventHandler() : staticHandler_(rspBuilder_), cgiHandler_(rspBuilder_) {
 
 }
@@ -12,67 +13,94 @@ EventHandler::~EventHandler() {
 
 }
 
-// 서버 fd에서 발생한 Read 이벤트 처리
-int	EventHandler::handleServerReadEvent(int fd, ClientManager& clientManager) {
-    struct sockaddr_in  clientAddr;
-    socklen_t           addrLen = sizeof(clientAddr);
+//---------------------------------------------------------------------
+// 서버 소켓(fd)에서 발생한 읽기 이벤트 처리
+// - 클라이언트 연결 요청을 수락하고, 클라이언트의 파일 디스크립터를 반환합니다.
+// - 연결 수락에 실패하면 -1을 반환합니다.
+//---------------------------------------------------------------------
+int EventHandler::handleServerReadEvent(int fd, ClientManager& clientManager) {
+    
+    struct sockaddr_in clientAddr;              // 클라이언트 주소 정보(IPv4)
+    socklen_t addrLen = sizeof(clientAddr);     // 클라이언트 주소 구조체의 크기
 
-    int clientFd = accept(fd, (struct sockaddr*)&clientAddr, &addrLen);
+    // accept() 호출을 통해 클라이언트 연결 수락
+    int clientFd = accept(fd, reinterpret_cast<struct sockaddr*>(&clientAddr), &addrLen);
     if (clientFd < 0) {
-        perror("client accept error");
+        // 연결 수락 실패
+        std::cerr << "[ERROR] Invalid Value - Failed accepting client (source: EventHandler.handleServerReadEvent)";
+        return -1;
     }
 
+    // 클라이언트의 IP 주소 문자열로 변환
     std::string clientIP(inet_ntoa(clientAddr.sin_addr));
+
+    // ClientManager에 새 클라이언트 정보를 추가
     clientManager.addClient(fd, clientFd, clientIP);
 
+    // 수락된 클라이언트의 파일 디스크립터 반환
     return clientFd;
 }
 
-// 클라이언트 fd에서 발생한 Read 이벤트 처리
-int	EventHandler::handleClientReadEvent(ClientSession& clientSession) {
-    int status = recvRequest(clientSession);
-    //recvRequest: EventHandler의 멤버 함수
-    //parser_: EventHandler의 멤버 변수
+//---------------------------------------------------------------------
+// 클라이언트 소켓(fd)에서 발생한 읽기 이벤트 처리
+// - 클라이언트로부터 요청 데이터를 수신하고, 요청 처리를 진행합니다.
+// - 요청 처리가 정상적으로 완료되면 응답 전송을 시도합니다.
+// - 요청 처리 중 에러가 발생하면 에러 응답을 전송합니다.
+//---------------------------------------------------------------------
+EnumSesStatus EventHandler::handleClientReadEvent(ClientSession& clientSession) {
+    // 클라이언트의 요청 데이터를 수신
+    EnumSesStatus status = recvRequest(clientSession);
 
     if (status == READ_COMPLETE) {
+        // 요청 데이터 수신이 완료된 경우
         RequestMessage  requestMsg = clientSession.getReqMsg();
-		std::string     responseMsg;
+        std::string     responseMsg;
 
-        // CGI 실행 여부 판별 및 응답 생성
-		if (cgiHandler_.isCGI(requestMsg.getTargetURI())) {
-			responseMsg = cgiHandler_.handleRequest(clientSession);
-		} else {
-			responseMsg = staticHandler_.handleRequest(requestMsg, clientSession.getConfig());
-		}
-        // 생성된 응답을 clientSession 내 write 버퍼에 저장
-		clientSession.setWriteBuffer(responseMsg);
-		
-        // 응답 전송 시도 및 sessionStatus 갱신
+        // 요청 URI에 CGI 실행 대상이 포함되어 있는지 확인
+        if (cgiHandler_.isCGI(requestMsg.getTargetURI())) {
+            // CGI 요청
+            responseMsg = cgiHandler_.handleRequest(clientSession);
+        } else {
+            // 정적 파일 요청
+            responseMsg = staticHandler_.handleRequest(requestMsg, clientSession.getConfig());
+        }
+        // 생성된 응답 메시지를 클라이언트 세션의 쓰기 버퍼에 저장
+        clientSession.setWriteBuffer(responseMsg);
+        
+        // 클라이언트에게 응답 전송을 시도하고, 전송 결과에 따라 상태 갱신
         status = sendResponse(clientSession);
     } else if (status == REQUEST_ERROR) {
+        // 요청 처리 도중 에러가 발생한 경우
+        // Http 상태 코드(에러)를 가져와서 에러 응답 전송
         int statusCode = clientSession.getErrorStatusCode();
-
         handleError(statusCode, clientSession);
     }
 
     return status;
 }
 
-// 클라이언트 fd에서 발생한 Write 이벤트 처리
-int EventHandler::handleClientWriteEvent(ClientSession& clientSession) {
-    // 응답 전송 시도 및 sessionStatus 갱신
-    int status = sendResponse(clientSession);
+//---------------------------------------------------------------------
+// 클라이언트 소켓(fd)에서 발생한 쓰기 이벤트 처리
+// - 클라이언트에게 응답 데이터를 전송합니다.
+//---------------------------------------------------------------------
+EnumSesStatus EventHandler::handleClientWriteEvent(ClientSession& clientSession) {
+    // 클라이언트에게 응답 전송을 시도하고, 전송 결과 상태를 반환
+    EnumSesStatus status = sendResponse(clientSession);
     
     return status;
 }
 
-void	EventHandler::handleError(int statusCode, ClientSession& clientSession) {
-	// 에러 응답 생성
+//---------------------------------------------------------------------
+// 에러 응답 처리 함수
+// - 에러 상태 코드에 따라 적절한 에러 응답 메시지를 생성 및 전송합니다.
+//---------------------------------------------------------------------
+void EventHandler::handleError(int statusCode, ClientSession& clientSession) {
+    // ResponseBuilder를 사용하여 상태 코드에 맞는 에러 응답 메시지 생성
     std::string errorMsg = rspBuilder_.buildError(statusCode, clientSession.getConfig());
 
-    // 생성된 응답을 clientSession 내 write 버퍼에 저장
-	clientSession.setWriteBuffer(errorMsg);
+    // 생성된 에러 메시지를 클라이언트 세션의 쓰기 버퍼에 저장
+    clientSession.setWriteBuffer(errorMsg);
 
-    // 응답 전송
-	sendResponse(clientSession);
+    // 클라이언트에게 에러 응답 전송
+    sendResponse(clientSession);
 }

--- a/src/EventHandler/EventHandler.hpp
+++ b/src/EventHandler/EventHandler.hpp
@@ -1,12 +1,6 @@
 #ifndef EVENT_HANDLER_HPP
 #define EVENT_HANDLER_HPP
 
-#include <string>
-#include <sys/socket.h>
-#include <netinet/in.h>
-#include <unistd.h>
-#include <cstdio>
-
 #include "../include/commonEnums.hpp"
 #include "../ClientManager/ClientManager.hpp"
 #include "../RequestMessage/RequestMessage.hpp"

--- a/src/EventHandler/EventHandler.hpp
+++ b/src/EventHandler/EventHandler.hpp
@@ -11,15 +11,15 @@
 
 // EventHandler 객체는 ServerManager::run()에서 사용됩니다.
 // ../ServerManager/ServerManagerRun.cpp
-// 클라이언트 세션의 이벤트 처리를 담당하는 클래스
+// 이벤트 처리를 담당하는 클래스
 class EventHandler {
 	public:
 		EventHandler();
 		~EventHandler();
-		int		handleServerReadEvent(int fd, ClientManager& clientManager);
-		int		handleClientReadEvent(ClientSession& clientSession);
-		int 	handleClientWriteEvent(ClientSession& clientSession);
-		void	handleError(int statusCode, ClientSession& clientSession);
+		int				handleServerReadEvent(int fd, ClientManager& clientManager);
+		EnumSesStatus	handleClientReadEvent(ClientSession& clientSession);
+		EnumSesStatus 	handleClientWriteEvent(ClientSession& clientSession);
+		void			handleError(int statusCode, ClientSession& clientSession);
 		
 	private:
 		RequestParser	parser_;
@@ -27,8 +27,8 @@ class EventHandler {
 		StaticHandler	staticHandler_;
 		CgiHandler		cgiHandler_;
 
-		EnumSesStatus		recvRequest(ClientSession& clientSession); //recv()
-		EnumSesStatus		sendResponse(ClientSession& clientSession); //send()
+		EnumSesStatus	recvRequest(ClientSession& clientSession); //recv()
+		EnumSesStatus	sendResponse(ClientSession& clientSession); //send()
 
 };
 

--- a/src/EventHandler/EventHandler.hpp
+++ b/src/EventHandler/EventHandler.hpp
@@ -22,7 +22,7 @@ class EventHandler {
 	public:
 		EventHandler();
 		~EventHandler();
-		int		handleServerReadEvent(int fd);
+		int		handleServerReadEvent(int fd, ClientManager& clientManager);
 		int		handleClientReadEvent(ClientSession& clientSession);
 		int 	handleClientWriteEvent(ClientSession& clientSession);
 		void	handleError(int statusCode, ClientSession& clientSession);


### PR DESCRIPTION

### 변경 사항

**1. ClientSession내 clientIP 정보 지원**
   : requestHandling 시 필요한 정보로 ClientSession 초기화시 세팅됩니다.
     ClientSession 생성 시 필요한 정보가 늘어남에 따라 생성 시점(clientManager.addClient())을 
     EventHandler의 handleServerReadEvent() 내부로 이동했습니다. 
     아직 ServerManager.run() 내 기존 생성 위치는 수정되지 않았으며, 이어서 작업할 이벤트 루프 리팩토링에서 해당 사항 반영할 예정입니다.
     이 외에도 IPv4주소를 문자열로 변환하는 로직도 추가되었습니다. 

**2. 기타**
- 의존성 개선을 위한 include 위치 수정 (이에 따라 recvRequest, sendResponse 구현파일 내 <sys/socket.h> 를 인클루드 해야합니다.)
- Client 이벤트 핸들리 메소드들의 반환값 수정: int -> EnumSesStatus
- 주석 추가


### 추후 변경 가능 사항
: recvRequest(), sendResponse() 파트 완성 및 멤버 변수 생성자 등 최종 명세가 변경될 경우 반영할 예정

