### PR TITLE
fix: atexit 대체 및 cpp98 표준에 맞추어 함수 수정

### DIFF
--- a/src/ConfigParser/ConfigParser.hpp
+++ b/src/ConfigParser/ConfigParser.hpp
@@ -4,13 +4,14 @@
 #include "../GlobalConfig/GlobalConfig.hpp"
 #include "utils.hpp"
 
-#include <string>            // std::string
-#include <vector>            // std::vector
-#include <map>               // std::map
-#include <fstream>           // std::ifstream
-#include <stdexcept>         // std::runtime_error
-#include <cctype>            // std::isdigit, std::isxdigit, std::isspace, std::tolower
-#include <iterator>          // std::iterator
+#include <string>			// std::string
+#include <vector>			// std::vector
+#include <map>				// std::map
+#include <fstream>			// std::ifstream
+#include <stdexcept>		// std::runtime_error
+#include <cctype>			// std::isdigit, std::isxdigit, std::isspace, std::tolower
+#include <iterator>			// std::iterator
+#include <cstdlib>			// strtoul
 
 class GlobalConfig;
 class ServerConfig;

--- a/src/ConfigParser/parse_server_block.cpp
+++ b/src/ConfigParser/parse_server_block.cpp
@@ -207,7 +207,7 @@ namespace {
 		}
 
 		// '-'는 시작이나 끝에 위치하면 안 됨
-		if (name.front() == '-' || name.back() == '-') {
+		if (name[0] == '-' || name[name.size() - 1] == '-') {
 			return false;
 		}
 

--- a/src/ConfigParser/parse_simple_directives.cpp
+++ b/src/ConfigParser/parse_simple_directives.cpp
@@ -128,7 +128,7 @@ void ConfigParser::parseClientMaxBodySize(std::ifstream& configFile, Optional<si
 		throw std::runtime_error("Unexpected end of file in client_max_body_size directive");
 	} else if (utils::all_of(nextToken.begin(), nextToken.end(), ::isdigit)) {
 		// 토큰을 unsigned long 형태로 변환 후 clientMaxBody에 저장
-		clientMaxBody = strtoul(nextToken);
+		clientMaxBody = strtoul(nextToken.c_str(), nullptr, 10);
 	} else {
 		throw std::runtime_error("Expected numeric value for client_max_body_size directive");
 	}

--- a/src/ConfigParser/parse_simple_directives.cpp
+++ b/src/ConfigParser/parse_simple_directives.cpp
@@ -14,7 +14,7 @@ void ConfigParser::parseErrorPage(std::ifstream& configFile, std::map<int, std::
 		} else if (utils::all_of(nextToken.begin(), nextToken.end(), ::isdigit)) {
 			// 에러 코드는 3자리여야 함
 			if (nextToken.size() == 3) {
-				int errorCode = std::stoi(nextToken);
+				int errorCode = utils::stoi(nextToken);
 				errorCodes.push_back(errorCode);
 			} else {
 				throw std::runtime_error("Invalid error code for error_page directive");
@@ -49,7 +49,7 @@ void ConfigParser::parseReturn(std::ifstream& configFile, std::string& returnUrl
 	if (utils::all_of(nextToken.begin(), nextToken.end(), ::isdigit)) {
 		if (nextToken.size() == 3) {
 			// 토큰을 int로 변환 후 returnStatus에 저장
-			returnStatus = std::stoi(nextToken);
+			returnStatus = utils::stoi(nextToken);
 		} else {
 			// 3자리가 아니면 예외 발생
 			throw std::runtime_error("Invalid HTTP status code for return directive");
@@ -128,7 +128,7 @@ void ConfigParser::parseClientMaxBodySize(std::ifstream& configFile, Optional<si
 		throw std::runtime_error("Unexpected end of file in client_max_body_size directive");
 	} else if (utils::all_of(nextToken.begin(), nextToken.end(), ::isdigit)) {
 		// 토큰을 unsigned long 형태로 변환 후 clientMaxBody에 저장
-		clientMaxBody = std::stoul(nextToken);
+		clientMaxBody = strtoul(nextToken);
 	} else {
 		throw std::runtime_error("Expected numeric value for client_max_body_size directive");
 	}

--- a/src/GlobalConfig/GlobalConfig.cpp
+++ b/src/GlobalConfig/GlobalConfig.cpp
@@ -20,8 +20,6 @@ void GlobalConfig::initGlobalConfig(const char* path) {
 	instance_ = new GlobalConfig();
 	ConfigParser::parse(*instance_, path);  // 설정 파일을 파싱하고 초기화 수행
 	isInitialized_ = true;
-	// 프로그램 종료 시 싱글톤 인스턴스 파괴를 위해 atexit에 등록
-	std::atexit(&GlobalConfig::destroyInstance);
 }
 
 // 싱글톤 인스턴스를 파괴

--- a/src/GlobalConfig/GlobalConfig.hpp
+++ b/src/GlobalConfig/GlobalConfig.hpp
@@ -7,6 +7,7 @@
 #include <vector>
 #include <map>
 #include <iostream>
+#include <cstddef>
 
 class ConfigParser;
 

--- a/src/ServerManager/ServerManager.cpp
+++ b/src/ServerManager/ServerManager.cpp
@@ -55,8 +55,7 @@ void ServerManager::setupListeningSockets() {
 }
 
 // 서버 구성에 따라 소켓을 생성하고 바인딩하고 수신 대기 상태로 전환하는 함수입니다.
-int ServerManager::createListeningSocket(const ServerConfig &server)
-{
+int ServerManager::createListeningSocket(const ServerConfig &server) const {
     int sockFd;
     struct addrinfo hints, *result, *currAddr;
     
@@ -110,7 +109,7 @@ int ServerManager::createListeningSocket(const ServerConfig &server)
 }
 
 // addrinfo 구조체의 힌트를 초기화하는 함수입니다.
-void ServerManager::initAddrInfo(struct addrinfo &hints) {
+void ServerManager::initAddrInfo(struct addrinfo &hints) const {
     // hints 구조체의 모든 필드를 0으로 초기화합니다.
     memset(&hints, 0, sizeof(hints));
     hints.ai_family = AF_INET;			// IPv4 허용
@@ -119,7 +118,7 @@ void ServerManager::initAddrInfo(struct addrinfo &hints) {
 }
 
 // 소켓 옵션과 논블로킹 모드를 설정하는 함수입니다.
-int ServerManager::configureSocket(int sockFd) {
+int ServerManager::configureSocket(int sockFd) const {
     if (setSocketOptions(sockFd) < 0) {
         return -1;
     }
@@ -130,7 +129,7 @@ int ServerManager::configureSocket(int sockFd) {
 }
 
 // 소켓을 논블로킹 모드로 설정하는 함수입니다.
-int ServerManager::setNonBlocking(int sockFd) {
+int ServerManager::setNonBlocking(int sockFd) const {
     // 현재 파일 디스크립터의 플래그를 가져옵니다.
     int flags = fcntl(sockFd, F_GETFL, 0);
     if (flags == -1) {
@@ -144,7 +143,7 @@ int ServerManager::setNonBlocking(int sockFd) {
 }
 
 // 로컬 주소 재사용을 허용하는 소켓 옵션을 설정하는 함수입니다.
-int ServerManager::setSocketOptions(int sockFd) {
+int ServerManager::setSocketOptions(int sockFd) const {
     int opt = 1;
     // SO_REUSEADDR 옵션을 활성화하여, 소켓을 빠르게 재사용할 수 있도록 합니다.
     if (setsockopt(sockFd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)) < 0) {

--- a/src/ServerManager/ServerManager.cpp
+++ b/src/ServerManager/ServerManager.cpp
@@ -11,6 +11,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <cstring>
+#include <sstream>
 
 // 프로그램 종료 시, 열려있는 소켓들을 닫기 위한 소멸자입니다.
 ServerManager::~ServerManager() {
@@ -53,19 +54,23 @@ void ServerManager::setupListeningSockets() {
     }
 }
 
-// 새 TCP 소켓을 생성하는 함수입니다.
+// 서버 구성에 따라 소켓을 생성하고 바인딩하고 수신 대기 상태로 전환하는 함수입니다.
 int ServerManager::createListeningSocket(const ServerConfig &server)
 {
+    int sockFd;
     struct addrinfo hints, *result, *currAddr;
-    char portStr[6];
     
     // 주소 정보를 위한 힌트 구조체를 초기화합니다.
     initAddrInfo(hints);
     // 포트 번호를 문자열로 변환합니다.
-    snprintf(portStr, sizeof(portStr), "%d", server.port_);
+	std::stringstream ss;
+	ss << server.port_;
+	std::string portStr = ss.str();
+	const char* portCStr = portStr.c_str();
 
     // 서버의 호스트명과 포트 번호를 기반으로 주소 정보를 가져옵니다.
-    if (getaddrinfo(server.host_.c_str(), portStr, &hints, &result)) {
+	int s = getaddrinfo(server.host_.c_str(), portCStr, &hints, &result);
+    if (s != 0) {
         throw std::runtime_error(std::string("getaddrinfo: ") + gai_strerror(s));
     }
 

--- a/src/ServerManager/ServerManager.cpp
+++ b/src/ServerManager/ServerManager.cpp
@@ -34,7 +34,7 @@ void ServerManager::setupListeningSockets() {
     for (size_t i = 0; i < globalConfig.servers_.size(); ++i) {
         ServerConfig &server = globalConfig.servers_[i];
         // 현재 서버의 호스트와 포트 정보를 키로 생성합니다.
-        std::pair<std::string, int> key = std::make_pair(server.host_, server.port_);
+        std::pair<std::string, int> key(server.host_, server.port_);
 
         int sockFd;
         // 해당 호스트/포트 조합에 대해 이미 소켓이 생성되었는지 확인합니다.
@@ -56,17 +56,18 @@ void ServerManager::setupListeningSockets() {
 
 // 서버 구성에 따라 소켓을 생성하고 바인딩하고 수신 대기 상태로 전환하는 함수입니다.
 int ServerManager::createListeningSocket(const ServerConfig &server) const {
-    int sockFd;
+    int sockFd = -1;
     struct addrinfo hints, *result, *currAddr;
     
     // 주소 정보를 위한 힌트 구조체를 초기화합니다.
     initAddrInfo(hints);
+    
     // 포트 번호를 문자열로 변환합니다.
 	std::stringstream ss;
 	ss << server.port_;
 	std::string portStr = ss.str();
 	const char* portCStr = portStr.c_str();
-
+    
     // 서버의 호스트명과 포트 번호를 기반으로 주소 정보를 가져옵니다.
 	int s = getaddrinfo(server.host_.c_str(), portCStr, &hints, &result);
     if (s != 0) {
@@ -175,5 +176,10 @@ void ServerManager::print() const {
 			std::cout << "server: " << it->second[i]->host_ << ":" << it->second[i]->port_ << std::endl;
 		}
 	}
+}
+
+// 주어진 파일 디스크립터(fd)가 수신 소켓인지 판단하는 함수
+bool ServerManager::isListeningSocket(int fd) {
+	return listenFds_.find(fd) != listenFds_.end();
 }
 

--- a/src/ServerManager/ServerManager.hpp
+++ b/src/ServerManager/ServerManager.hpp
@@ -19,7 +19,7 @@ class ServerManager {
         // 서버 실행 함수: 메인 이벤트 루프를 돌며 클라이언트 연결 및 데이터 송수신, 타임아웃 관리 등을 수행
         void run();
         // 서버 실행 여부 확인 함수: 서버가 정상적으로 실행 중인지 판단
-        bool isServerRunning();
+        bool isServerRunning() const;
 		// 디버깅을 위한 현재 수신 소켓 정보 출력 함수
 		void print() const;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,10 +10,17 @@ int main(int argc, char** argv) {
 		std::cerr << "Usage: ./webserver [config file path]" << std::endl;
 		return 1;
 	}
-	GlobalConfig::initGlobalConfig(argv[1]);
-	setupSignalHandlers();
-	ServerManager serverManager;
-	serverManager.setupListeningSockets();
-	serverManager.run();
+	try {
+		GlobalConfig::initGlobalConfig(argv[1]);
+		setupSignalHandlers();
+		ServerManager serverManager;
+		serverManager.setupListeningSockets();
+		serverManager.run();
+	} catch (const std::exception& e) {
+		GlobalConfig::destroyInstance();
+		std::cerr << "Error: " << e.what() << std::endl;
+		return 1;
+	}
+	GlobalConfig::destroyInstance();
 	return 0;
 }

--- a/src/utils/file_utils.cpp
+++ b/src/utils/file_utils.cpp
@@ -1,76 +1,76 @@
 #include "file_utils.hpp"
 
-using namespace FileUtilities;
+namespace FileUtilities {
+	EnumValidationResult validatePath(const std::string& path)
+	{
+		// 1) stat으로 파일 정보를 가져온다
+		struct stat st;
 
-EnumValidationResult validatePath(const std::string& path)
-{
-	// 1) stat으로 파일 정보를 가져온다
-	struct stat st;
+		if (stat(path.c_str(), &st) != 0) {
+			// 경로가 존재하지 않는 경우
+			// "마지막 문자가 '/'이면 디렉터리로 간주, 아니면 파일"로 구분
+			if (!path.empty() && path[path.size() - 1] == '/') {
+				return PATH_NOT_FOUND;
+			} else {
+				return FILE_NOT_FOUND;
+			}
+		}
 
-	if (stat(path.c_str(), &st) != 0) {
-		// 경로가 존재하지 않는 경우
-		// "마지막 문자가 '/'이면 디렉터리로 간주, 아니면 파일"로 구분
-		if (!path.empty() && path.back() == '/') {
-			return PATH_NOT_FOUND;
-		} else {
+		// 2) 경로가 디렉터리인지 확인
+		if (S_ISDIR(st.st_mode)) {
+			// 디렉터리 접근 권한(검색 권한, X_OK) 체크
+			if (access(path.c_str(), X_OK) != 0) {
+				return PATH_NO_PERMISSION;
+			}
+			return VALID_PATH;
+		}
+		// 3) 경로가 정규파일인지 확인
+		else if (S_ISREG(st.st_mode)) {
+			// 먼저 읽기 권한(R_OK) 체크
+			if (access(path.c_str(), R_OK) != 0) {
+				return FILE_NO_READ_PERMISSION;
+			}
+			// 다음으로 실행 권한(X_OK) 체크
+			if (access(path.c_str(), X_OK) != 0) {
+				return FILE_NO_EXEC_PERMISSION;
+			}
+			return VALID_FILE;
+		}
+		// 4) 그 밖의 유형(심볼릭 링크, 소켓, 파이프 등)은 "정규파일이 아니다"로 처리
+		else {
 			return FILE_NOT_FOUND;
 		}
 	}
 
-	// 2) 경로가 디렉터리인지 확인
-	if (S_ISDIR(st.st_mode)) {
-		// 디렉터리 접근 권한(검색 권한, X_OK) 체크
-		if (access(path.c_str(), X_OK) != 0) {
-			return PATH_NO_PERMISSION;
+	// 파일을 읽어 문자열로 반환하는 함수
+	std::string readFile(const std::string &filePath) {
+		// 파일을 바이너리 모드로 열고, 파일 끝에 위치하여 크기를 측정
+		std::ifstream file(filePath.c_str(), std::ios::in | std::ios::binary | std::ios::ate);
+
+		// 파일을 열지 못한 경우 빈 문자열 반환
+		if (!file.is_open()) {
+			return "";
 		}
-		return VALID_PATH;
-	}
-	// 3) 경로가 정규파일인지 확인
-	else if (S_ISREG(st.st_mode)) {
-		// 먼저 읽기 권한(R_OK) 체크
-		if (access(path.c_str(), R_OK) != 0) {
-			return FILE_NO_READ_PERMISSION;
+
+		// 파일 크기를 얻어옴
+		std::ifstream::pos_type fileSize = file.tellg();
+		// 파일 포인터를 파일의 시작 위치로 이동
+		file.seekg(0, std::ios::beg);
+
+		// 파일 크기가 음수인 경우(비정상적인 상태) 빈 문자열 반환
+		if (fileSize < 0) {
+			return "";
 		}
-		// 다음으로 실행 권한(X_OK) 체크
-		if (access(path.c_str(), X_OK) != 0) {
-			return FILE_NO_EXEC_PERMISSION;
+
+		// 파일 크기만큼의 버퍼를 생성
+		std::vector<char> buffer(static_cast<size_t>(fileSize));
+
+		// 파일을 읽고, 실패 시 빈 문자열 반환
+		if (!file.read(&buffer[0], fileSize)) {
+			return "";
 		}
-		return VALID_FILE;
+
+		// 버퍼를 문자열로 변환하여 반환
+		return std::string(buffer.begin(), buffer.end());
 	}
-	// 4) 그 밖의 유형(심볼릭 링크, 소켓, 파이프 등)은 "정규파일이 아니다"로 처리
-	else {
-		return FILE_NOT_FOUND;
-	}
-}
-
-// 파일을 읽어 문자열로 반환하는 함수
-std::string readFile(const std::string &filePath) {
-	// 파일을 바이너리 모드로 열고, 파일 끝에 위치하여 크기를 측정
-	std::ifstream file(filePath.c_str(), std::ios::in | std::ios::binary | std::ios::ate);
-
-	// 파일을 열지 못한 경우 빈 문자열 반환
-	if (!file.is_open()) {
-		return "";
-	}
-
-	// 파일 크기를 얻어옴
-	std::ifstream::pos_type fileSize = file.tellg();
-	// 파일 포인터를 파일의 시작 위치로 이동
-	file.seekg(0, std::ios::beg);
-
-	// 파일 크기가 음수인 경우(비정상적인 상태) 빈 문자열 반환
-	if (fileSize < 0) {
-		return "";
-	}
-
-	// 파일 크기만큼의 버퍼를 생성
-	std::vector<char> buffer(static_cast<size_t>(fileSize));
-
-	// 파일을 읽고, 실패 시 빈 문자열 반환
-	if (!file.read(&buffer[0], fileSize)) {
-		return "";
-	}
-
-	// 버퍼를 문자열로 변환하여 반환
-	return std::string(buffer.begin(), buffer.end());
 }

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -20,7 +20,7 @@ namespace utils {
 	int stoi(const std::string& str) {
 		char* end; // 숫자열의 끝을 가리킬 포인터
 		errno = 0; // 호출 전에 errno를 초기화
-		long result = std::strtol(str.c_str(), &end, 10); // 10진수로 변환
+		long result = strtol(str.c_str(), &end, 10); // 10진수로 변환
 
 		// 오버플로우 처리
 		if (errno == ERANGE || result > INT_MAX || result < INT_MIN) {
@@ -39,7 +39,7 @@ namespace utils {
 	size_t sto_size_t(const std::string& str) {
 		char* end;
 		errno = 0;
-		unsigned long result = std::strtoul(str.c_str(), &end, 10);
+		unsigned long result = strtoul(str.c_str(), &end, 10);
 
 		// 오버플로우 처리
 		if (errno == ERANGE || result > std::numeric_limits<size_t>::max()) {

--- a/src/utils/utils.hpp
+++ b/src/utils/utils.hpp
@@ -11,6 +11,7 @@
 #include <csignal>
 #include <iostream>
 #include <limits>
+#include <cstdlib>
 
 // 유틸리티 함수들을 담는 네임스페이스
 namespace utils {


### PR DESCRIPTION
- atexit을 삭제하고 main문에 try-catch문을 도입했습니다.
- cpp98에 맞지 않는 함수들을 수정했습니다.
- 네임스페이스가 올바르지 않은 코드를 수정했습니다.
- ServerManager의 메서드들에 const 수식어를 추가했습니다.
- ServerManager.hpp에서 isServerRunning() 함수에 const 한정자 추가
- std::make_pair 대신 직접 pair 생성자 사용
- isListeningSocket 함수 구현 추가
- 변수 초기화 위치 수정 및 공백 정리

이슈 번호: #126, #133