### PR TITLE
feat: CgiHandler::isCGI() 로직 수정

### DIFF
--- a/src/EventHandler/EventHandler.cpp
+++ b/src/EventHandler/EventHandler.cpp
@@ -55,14 +55,15 @@ EnumSesStatus EventHandler::handleClientReadEvent(ClientSession& clientSession) 
         // 요청 데이터 수신이 완료된 경우
         RequestMessage  requestMsg = clientSession.getReqMsg();
         std::string     responseMsg;
+		RequestConfig&	reqConfig = clientSession.getConfig();
 
         // 요청 URI에 CGI 실행 대상이 포함되어 있는지 확인
-        if (cgiHandler_.isCGI(requestMsg.getTargetURI())) {
+        if (cgiHandler_.isCGI(requestMsg.getTargetURI(), reqConfig.cgiExtension_)) {
             // CGI 요청
             responseMsg = cgiHandler_.handleRequest(clientSession);
         } else {
             // 정적 파일 요청
-            responseMsg = staticHandler_.handleRequest(requestMsg, clientSession.getConfig());
+            responseMsg = staticHandler_.handleRequest(requestMsg, reqConfig);
         }
         // 생성된 응답 메시지를 클라이언트 세션의 쓰기 버퍼에 저장
         clientSession.setWriteBuffer(responseMsg);

--- a/src/RequestHandler/CgiHandler.cpp
+++ b/src/RequestHandler/CgiHandler.cpp
@@ -22,9 +22,13 @@ CgiHandler::~CgiHandler() {
 }
 
 // 요청된 URI가 CGI 실행 대상인지 확인하는 함수
-bool CgiHandler::isCGI(const std::string& targetUri) {
-    // URI가 "/cgi-bin/"으로 시작하면 CGI 스크립트로 간주
-    return targetUri.find("/cgi-bin/") == 0;
+bool CgiHandler::isCGI(const std::string& targetUri, const std::string& cgiExtension)
+{
+	// targetUri가 cgiExtension으로 끝나면 true 반환
+    if (targetUri.size() < cgiExtension.size()) {
+		return false;
+	}
+    return targetUri.compare(targetUri.size() - cgiExtension.size(), cgiExtension.size(), cgiExtension) == 0;
 }
 
 // 클라이언트의 요청을 처리하여 CGI 결과를 반환하는 함수

--- a/src/RequestHandler/CgiHandler.hpp
+++ b/src/RequestHandler/CgiHandler.hpp
@@ -22,7 +22,7 @@ public:
     ~CgiHandler();
 
     // 주어진 URI가 CGI 대상인지 확인하는 함수
-    bool isCGI(const std::string& targetUri);
+    bool isCGI(const std::string& targetUri, const std::string& cgiExtension);
     // 클라이언트 요청을 처리하여 CGI 실행 결과를 반환하는 함수
     std::string handleRequest(const ClientSession& clientSession);
 


### PR DESCRIPTION
- 설정파일에서 정의된 내용대로 cgi 스크립트를 구별하도록 수정했습니다.
- 요청 url이 설정파일에서 정의된 문자열로 끝날때 cgi 스크립트로 간주합니다.