### PR TITLE
feat: 기본 에러 페이지 템플릿 구현

### DIFF
--- a/html/error/default_error.html
+++ b/html/error/default_error.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>{{ERROR_CODE}} {{ERROR_TEXT}}</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            text-align: center;
+            margin-top: 50px;
+            background-color: #f5f5f5;
+        }
+        .error-container {
+            background-color: white;
+            border-radius: 10px;
+            box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+            padding: 30px;
+            max-width: 600px;
+            margin: 0 auto;
+        }
+        h1 {
+            color: #e74c3c;
+            font-size: 36px;
+            margin-bottom: 10px;
+        }
+        .status-code {
+            font-size: 24px;
+            color: #7f8c8d;
+            margin-bottom: 20px;
+        }
+        .description {
+            color: #34495e;
+            margin-bottom: 30px;
+            line-height: 1.5;
+        }
+        footer {
+            margin-top: 30px;
+            color: #95a5a6;
+            font-size: 14px;
+        }
+    </style>
+</head>
+<body>
+    <div class="error-container">
+        <h1>{{ERROR_TEXT}}</h1>
+        <div class="status-code">Error {{ERROR_CODE}}</div>
+        <div class="description">
+            {{ERROR_DESCRIPTION}}
+        </div>
+    </div>
+    <footer>Webserv HTTP Server</footer>
+</body>
+</html>

--- a/src/ResponseBuilder/ErrorPageResolver.cpp
+++ b/src/ResponseBuilder/ErrorPageResolver.cpp
@@ -1,31 +1,119 @@
-#include "ErrorPageResolver.hpp" // 헤더 파일 포함
+#include "ErrorPageResolver.hpp"
+#include "commonEnums.hpp"
+#include <algorithm>
 
 namespace ErrorPageResolver {
+	// 상태 코드에 따른 텍스트 설명을 반환하는 함수
+	std::string getStatusText(int errorCode) {
+		switch (errorCode) {
+			case OK: return "OK";
+			case MOVED_PERMANENTLY: return "Moved Permanently";
+			case FOUND: return "Found";
+			case BAD_REQUEST: return "Bad Request";
+			case FORBIDDEN: return "Forbidden";
+			case NOT_FOUND: return "Not Found";
+			case METHOD_NOT_ALLOWED: return "Method Not Allowed";
+			case REQUEST_TIMEOUT: return "Request Timeout";
+			case CONTENT_TOO_LARGE: return "Payload Too Large";
+			case INTERNAL_SERVER_ERROR: return "Internal Server Error";
+			case NOT_IMPLEMENTED: return "Not Implemented";
+			case SERVICE_UNAVAILABLE: return "Service Unavailable";
+			default: return "Unknown Error";
+		}
+	}
+
+	// 에러 코드에 따른 상세 설명 반환 함수
+	std::string getErrorDescription(int errorCode) {
+		switch (errorCode) {
+			case BAD_REQUEST:
+				return "The request could not be understood by the server due to malformed syntax.";
+			case FORBIDDEN:
+				return "You don't have permission to access this resource.";
+			case NOT_FOUND:
+				return "The requested resource could not be found on this server.";
+			case METHOD_NOT_ALLOWED:
+				return "The method specified in the request is not allowed for the resource.";
+			case REQUEST_TIMEOUT:
+				return "The server timed out waiting for the request.";
+			case CONTENT_TOO_LARGE:
+				return "The request entity is larger than the server is willing or able to process.";
+			case INTERNAL_SERVER_ERROR:
+				return "The server encountered an unexpected condition that prevented it from fulfilling the request.";
+			case NOT_IMPLEMENTED:
+				return "The server does not support the functionality required to fulfill the request.";
+			case SERVICE_UNAVAILABLE:
+				return "The server is currently unable to handle the request due to temporary overloading or maintenance.";
+			default:
+				return "An error occurred while processing your request.";
+		}
+	}
+
+	// 템플릿 파일의 플레이스홀더를 실제 에러 정보로 대체하는 함수
+	std::string replaceTemplatePlaceholders(const std::string& templateContent, int errorCode) {
+		std::string result = templateContent;
+		std::string statusText = getStatusText(errorCode);
+		std::string errorDescription = getErrorDescription(errorCode);
+		std::string codeStr;
+		
+		// 에러 코드를 문자열로 변환
+		std::ostringstream oss;
+		oss << errorCode;
+		codeStr = oss.str();
+		
+		// 플레이스홀더 치환
+		size_t pos;
+		
+		// {{ERROR_CODE}} 대체
+		while ((pos = result.find("{{ERROR_CODE}}")) != std::string::npos) {
+			result.replace(pos, 15, codeStr);
+		}
+		
+		// {{ERROR_TEXT}} 대체
+		while ((pos = result.find("{{ERROR_TEXT}}")) != std::string::npos) {
+			result.replace(pos, 15, statusText);
+		}
+		
+		// {{ERROR_DESCRIPTION}} 대체
+		while ((pos = result.find("{{ERROR_DESCRIPTION}}")) != std::string::npos) {
+			result.replace(pos, 22, errorDescription);
+		}
+		
+		return result;
+	}
+
 	// 주어진 에러 코드에 해당하는 에러 페이지의 내용을 반환하는 함수
 	std::string resolveErrorPage(int errorCode, const std::map<int, std::string>& errorPages) {
 		std::string bodyContent; // 에러 페이지의 내용(본문)을 저장할 변수
 
-		// errorPages_ 맵에서 해당 에러 코드에 맞는 사용자 정의 에러 페이지 경로를 찾습니다.
+		// 사용자 정의 에러 페이지를 먼저 찾아봅니다.
 		std::map<int, std::string>::const_iterator it = errorPages.find(errorCode);
 		if (it != errorPages.end()) {
-			const std::string& customPath = it->second; // 사용자 정의 에러 페이지 파일 경로
-			bodyContent = FileUtilities::readFile(customPath); // 해당 파일을 읽어 내용 저장
+			const std::string& customPath = it->second;
+			bodyContent = FileUtilities::readFile(customPath);
 		}
 
-		// 사용자 정의 에러 페이지를 찾지 못했거나 파일 내용이 비어있다면 기본 에러 페이지를 사용합니다.
+		// 사용자 정의 에러 페이지가 없거나 내용이 비어있다면 기본 템플릿을 사용합니다.
 		if (bodyContent.empty()) {
-			std::ostringstream defaultPath;
-			// 기본 에러 페이지 경로 생성: 기본 디렉토리 + "/error" + 에러코드 + ".html"
-			defaultPath << DEFAULT_ERROR_DIRECTORY << "/error" << errorCode << ".html"; // 에러페이지 파일 이름 컨벤션 필요!
-			bodyContent = FileUtilities::readFile(defaultPath.str()); // 기본 경로의 파일을 읽어 내용 저장
+			// 기본 에러 페이지 템플릿 로드
+			std::string templateContent = FileUtilities::readFile(DEFAULT_ERROR_TEMPLATE);
+			
+			// 템플릿이 로드되었으면 플레이스홀더 교체
+			if (!templateContent.empty()) {
+				bodyContent = replaceTemplatePlaceholders(templateContent, errorCode);
+			} 
+			// 템플릿을 찾지 못했다면 간단한 HTML 에러 페이지 생성
+			else {
+				std::ostringstream fallbackHtml;
+				fallbackHtml << "<!DOCTYPE html><html><head><title>Error " << errorCode 
+							<< "</title></head><body><h1>Error " << errorCode 
+							<< " - " << getStatusText(errorCode) 
+							<< "</h1><p>" << getErrorDescription(errorCode) 
+							<< "</p></body></html>";
+				bodyContent = fallbackHtml.str();
+			}
 		}
 
-		// 파일을 읽었는데도 내용이 없다면 빈 문자열로 처리
-		if (bodyContent.empty()) {
-			bodyContent = "";
-		}
-
-		return bodyContent; // 최종적으로 에러 페이지의 내용을 반환
+		return bodyContent;
 	}
 }
 

--- a/src/ResponseBuilder/ErrorPageResolver.hpp
+++ b/src/ResponseBuilder/ErrorPageResolver.hpp
@@ -6,11 +6,14 @@
 #include <map>
 #include <string>
 
-#define DEFAULT_ERROR_DIRECTORY "../error/"
+#define DEFAULT_ERROR_TEMPLATE "html/error/default_error.html"
 
 // ErrorPageResolver 클래스: 에러 코드에 따른 에러 페이지 파일을 찾고 내용을 반환하는 역할을 합니다.
 namespace ErrorPageResolver {
 	std::string resolveErrorPage(int errorCode, const std::map<int, std::string>& errorPages);
+	std::string getErrorDescription(int errorCode);
+	std::string getStatusText(int errorCode);
+	std::string replaceTemplatePlaceholders(const std::string& templateContent, int errorCode);
 };
 
 #endif


### PR DESCRIPTION
- HTML/error 디렉토리 생성 및 default_error.html 템플릿 파일 추가
- 템플릿에 {{ERROR_CODE}}, {{ERROR_TEXT}}, {{ERROR_DESCRIPTION}} 플레이스홀더 적용
- ErrorPageResolver 클래스 확장:
  - 템플릿 파일 로드 및 플레이스홀더 치환 기능 추가
  - 상태 코드별 설명 텍스트 생성 함수 추가
  - 폴백 메커니즘으로 최소 텍스트 에러 페이지 구현

관련 이슈: #103