### PR TITLE
fix: error status를 전역 스코프에서 호출하도록 수정

### DIFF
--- a/src/ClientManager/ClientManager.cpp
+++ b/src/ClientManager/ClientManager.cpp
@@ -1,4 +1,5 @@
 #include "ClientManager.hpp"
+#include "../include/errorUtils.hpp"
 
 ClientManager::ClientManager() {
 	// 생성자
@@ -25,7 +26,7 @@ ClientManager::TypeClientMap::iterator ClientManager::removeClient(int fd) {
 	TypeClientMap::iterator it = clientList_.find(fd);
 	if (it == clientList_.end()) {
 		// 존재하지 않는 fd에 대한 요청 시 오류 로깅
-		webserv::logError(webserv::WARNING, "Client Fd Not Found", 
+		webserv::logError(WARNING, "Client Fd Not Found", 
 		                 "fd: " + std::to_string(fd), 
 		                 "ClientManager::removeClient");
 		return clientList_.end(); // 유효하지 않은 반복자 반환

--- a/src/Demultiplexer/KqueueDemultiplexer.cpp
+++ b/src/Demultiplexer/KqueueDemultiplexer.cpp
@@ -2,6 +2,7 @@
 #include <iostream>
 #include <sys/event.h>
 #include <unistd.h>
+#include "../include/errorUtils.hpp"
 
 // 생성자: kqueue를 생성하고, 리스닝 소켓들을 이벤트 감지 목록에 추가
 KqueueDemultiplexer::KqueueDemultiplexer(std::set<int>& listenFds) : eventList_(MAX_EVENT) {

--- a/src/EventHandler/EventHandler.cpp
+++ b/src/EventHandler/EventHandler.cpp
@@ -3,6 +3,7 @@
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
+#include "../include/errorUtils.hpp"
 
 // ResponseBuilder를 인자로 하여 정적 핸들러와 CGI 핸들러를 초기화합니다.
 EventHandler::EventHandler() : staticHandler_(rspBuilder_), cgiHandler_(rspBuilder_) {
@@ -27,7 +28,7 @@ int EventHandler::handleServerReadEvent(int fd, ClientManager& clientManager) {
     int clientFd = accept(fd, reinterpret_cast<struct sockaddr*>(&clientAddr), &addrLen);
     if (clientFd < 0) {
         // 연결 수락 실패 - 시스템 호출 에러를 로깅
-        webserv::logSystemError(webserv::ERROR, "accept", 
+        webserv::logSystemError(ERROR, "accept", 
                               "Server fd: " + std::to_string(fd), 
                               "EventHandler::handleServerReadEvent");
         return -1;

--- a/src/EventHandler/EventHandlerRecvRequest.cpp
+++ b/src/EventHandler/EventHandlerRecvRequest.cpp
@@ -2,6 +2,7 @@
 #include <iostream>
 #define _DARWIN_C_SOURCE
 #include <sys/socket.h>
+#include "../include/errorUtils.hpp"
 
 #ifndef BUFFER_SIZE
 # define BUFFER_SIZE 8192 //== 8KB
@@ -17,14 +18,14 @@ EnumSesStatus EventHandler::recvRequest(ClientSession &curSession) {
 		||  errno == EWOULDBLOCK	//errno)non-blocking 모드에서 읽을 데이터가 없어 즉시 반환된 경우
 		||  errno == EINTR) {		//errno)인터럽트, 시스템 호출 중 시그널에 의해 중단되어 호출이 완료되지 않은 경우
 			// 일시적인 문제(non-blocking, 인터럽트)는 WARNING 레벨로 로깅
-			webserv::logSystemError(webserv::WARNING, "recv", 
+			webserv::logSystemError(WARNING, "recv", 
 			                      "Client fd: " + std::to_string(curSession.getClientFd()), 
 			                      "EventHandler::recvRequest");
 			return READ_CONTINUE;
 		}
 			
 		// 심각한 오류 발생 시 ERROR 레벨로 로그만 출력하고 연결 종료 (서버는 계속 실행)
-		webserv::logSystemError(webserv::ERROR, "recv", 
+		webserv::logSystemError(ERROR, "recv", 
 		                      "Client fd: " + std::to_string(curSession.getClientFd()),
 		                      "EventHandler::recvRequest");
 		return CONNECTION_CLOSED;	//errno)그 외, 통신을 할 수 없는 상태이거나, 메모리 문제로 치명적인 경우

--- a/src/ServerManager/ServerManager.cpp
+++ b/src/ServerManager/ServerManager.cpp
@@ -12,6 +12,7 @@
 #include <fcntl.h>
 #include <cstring>
 #include <sstream>
+#include "../include/errorUtils.hpp"
 
 // 프로그램 종료 시, 열려있는 소켓들을 닫기 위한 소멸자입니다.
 ServerManager::~ServerManager() {
@@ -184,4 +185,3 @@ void ServerManager::print() const {
 bool ServerManager::isListeningSocket(int fd) {
 	return listenFds_.find(fd) != listenFds_.end();
 }
-

--- a/src/ServerManager/ServerManagerRun.cpp
+++ b/src/ServerManager/ServerManagerRun.cpp
@@ -1,4 +1,5 @@
 #include "ServerManager.hpp"
+#include "../include/errorUtils.hpp"
 
 // 서버의 메인 이벤트 루프를 실행합니다.
 // - EventHandler: 클라이언트 및 서버 이벤트 처리를 담당합니다.
@@ -106,7 +107,7 @@ void ServerManager::processClientReadEvent(int fd, ClientManager& clientManager,
 	ClientSession* client = clientManager.accessClientSession(fd);
 	if (!client) {
 		// 유효하지 않은 클라이언트 FD인 경우 경고 로깅 후 종료
-		webserv::logError(webserv::WARNING, "Invalid Value", 
+		webserv::logError(WARNING, "Invalid Value", 
 		                 "No clientSession corresponding to fd: " + std::to_string(fd), 
 		                 "ServerManager::processClientReadEvent");
 		return;
@@ -135,7 +136,7 @@ void ServerManager::processClientWriteEvent(int fd, ClientManager& clientManager
 	ClientSession* client = clientManager.accessClientSession(fd);
 	if (!client) {
 		// 유효하지 않은 클라이언트 FD인 경우 경고 로깅 후 종료
-		webserv::logError(webserv::WARNING, "Invalid Value", 
+		webserv::logError(WARNING, "Invalid Value", 
 		                 "No clientSession corresponding to fd: " + std::to_string(fd), 
 		                 "ServerManager::processClientWriteEvent");
 		return;

--- a/src/utils/examples/README.md
+++ b/src/utils/examples/README.md
@@ -28,21 +28,21 @@
 ### 2. 일반 에러 로깅
 ```cpp
 // WARNING 레벨 에러
-webserv::logError(webserv::WARNING, "Invalid value", "Input is negative", "validateInput function");
+webserv::logError(WARNING, "Invalid value", "Input is negative", "validateInput function");
 
 // ERROR 레벨 에러
-webserv::logError(webserv::ERROR, "File opening failed", "test.txt", 
+webserv::logError(ERROR, "File opening failed", "test.txt", 
                  "errno " + std::to_string(errno) + ", " + std::strerror(errno));
 ```
 
 ### 3. 시스템 호출 에러 로깅 (errno 자동 처리)
 ```cpp
 // WARNING 레벨 에러
-webserv::logSystemError(webserv::WARNING, "recv failed", 
+webserv::logSystemError(WARNING, "recv failed", 
 			                 "Client fd: " + std::to_string(curSession.getClientFd()), 
 			                 "EventHandler::recvRequest");
 // ERROR 레벨 에러
-webserv::logSystemError(webserv::ERROR, "fopen", "test.txt");
+webserv::logSystemError(ERROR, "fopen", "test.txt");
 ```
 
 ### 4. 예외 발생 (FATAL 에러)

--- a/src/utils/examples/error_handling_example.cpp
+++ b/src/utils/examples/error_handling_example.cpp
@@ -8,7 +8,7 @@ int main() {
     // 1. WARNING 레벨 에러 로그 예시 (파라미터 검증)
     int value = -10;
     if (value < 0) {
-        webserv::logError(webserv::WARNING, "Invalid value", "Input is negative", 
+        webserv::logError(WARNING, "Invalid value", "Input is negative", 
                          "validateInput function");
         value = 0; // 기본값으로 복구
     }
@@ -19,7 +19,7 @@ int main() {
 		if (errno == EAGAIN
 		||  errno == EWOULDBLOCK
 		||  errno == EINTR) {
-			webserv::logSystemError(webserv::WARNING, "recv failed", 
+			webserv::logSystemError(WARNING, "recv failed", 
 				"Client fd: " + std::to_string(curSession.getClientFd()), 
 				"EventHandler::recvRequest");
 			return READ_CONTINUE;
@@ -29,7 +29,7 @@ int main() {
     // 3. ERROR 레벨 에러 로그 예시 (파일 열기 실패)
     std::ifstream file("non_existent_file.txt");
     if (!file.is_open()) {
-        webserv::logError(webserv::ERROR, "File opening failed", "non_existent_file.txt", 
+        webserv::logError(ERROR, "File opening failed", "non_existent_file.txt", 
                          "errno " + std::to_string(errno) + ", " + std::strerror(errno));
         // 에러 발생 후 복구 시도 또는 대체 작업 수행
     }

--- a/src/utils/file_utils.cpp
+++ b/src/utils/file_utils.cpp
@@ -11,12 +11,12 @@ namespace FileUtilities {
 			// 경로가 존재하지 않는 경우
 			// "마지막 문자가 '/'이면 디렉터리로 간주, 아니면 파일"로 구분
 			if (!path.empty() && path[path.size() - 1] == '/') {
-				webserv::logError(webserv::WARNING, "Path not found", 
+				webserv::logError(WARNING, "Path not found", 
 				                 path, 
 				                 "FileUtilities::validatePath, errno: " + std::to_string(errno));
 				return PATH_NOT_FOUND;
 			} else {
-				webserv::logError(webserv::WARNING, "File not found", 
+				webserv::logError(WARNING, "File not found", 
 				                 path, 
 				                 "FileUtilities::validatePath, errno: " + std::to_string(errno));
 				return FILE_NOT_FOUND;
@@ -56,7 +56,7 @@ namespace FileUtilities {
 
 		// 파일을 열지 못한 경우 에러 로깅 후 빈 문자열 반환
 		if (!file.is_open()) {
-			webserv::logError(webserv::ERROR, "File opening failed", 
+			webserv::logError(ERROR, "File opening failed", 
 			                 filePath, 
 			                 "FileUtilities::readFile, errno: " + std::to_string(errno));
 			return "";
@@ -69,7 +69,7 @@ namespace FileUtilities {
 
 		// 파일 크기가 음수인 경우(비정상적인 상태) 에러 로깅 후 빈 문자열 반환
 		if (fileSize < 0) {
-			webserv::logError(webserv::ERROR, "Invalid file size", 
+			webserv::logError(ERROR, "Invalid file size", 
 			                 filePath + ", size: " + std::to_string(fileSize), 
 			                 "FileUtilities::readFile");
 			return "";
@@ -80,7 +80,7 @@ namespace FileUtilities {
 
 		// 파일을 읽고, 실패 시 에러 로깅 후 빈 문자열 반환
 		if (!file.read(&buffer[0], fileSize)) {
-			webserv::logError(webserv::ERROR, "File read failed", 
+			webserv::logError(ERROR, "File read failed", 
 			                 filePath + ", requested size: " + std::to_string(fileSize), 
 			                 "FileUtilities::readFile");
 			return "";


### PR DESCRIPTION
- errorUtils.hpp를 상대경로로 include하도록 수정

이슈 번호: #68