### PR TITLE
fix : Kqueue의 EVFILT_EXCEPT 감지 비활성화

### DIFF
--- a/src/EventHandler/EventHandler.cpp
+++ b/src/EventHandler/EventHandler.cpp
@@ -40,6 +40,7 @@ int EventHandler::handleServerReadEvent(int fd, ClientManager& clientManager) {
     // ClientManager에 새 클라이언트 정보를 추가
     clientManager.addClient(fd, clientFd, clientIP);
 
+    std::clog << "  Accepted CLIENT SOCKET : " << clientFd << std::endl;
     // 수락된 클라이언트의 파일 디스크립터 반환
     return clientFd;
 }

--- a/src/EventHandler/EventHandlerRecvRequest.cpp
+++ b/src/EventHandler/EventHandlerRecvRequest.cpp
@@ -32,6 +32,9 @@ EnumSesStatus EventHandler::recvRequest(ClientSession &curSession) {
 	} else if (res == 0) {			//클라이언트 측에서 연결을 종료한 경우
 		return CONNECTION_CLOSED;
 	} else {
+		// 수신한 내용 출력(로그용)
+		std::clog << "[Received MSG]\n" << buffer << std::endl;
+
 		// 해당 ClientSession의 RequestMessage를 파싱하기 전에 Body의 최대 길이를 설정
 		const RequestConfig *config = curSession.getConfigPtr();
 		const size_t bodyMax = (config == NULL) ? BODY_MAX_LENGTH : config->clientMaxBodySize_.value();

--- a/src/EventHandler/EventHandlerRecvRequest.cpp
+++ b/src/EventHandler/EventHandlerRecvRequest.cpp
@@ -38,7 +38,7 @@ EnumSesStatus EventHandler::recvRequest(ClientSession &curSession) {
 		this->parser_.setConfigBodyLength(bodyMax);
 
 		// 이전에 버퍼 저장해놓은 데이터와 새로운 요청 데이터를 가지고 파싱
-		EnumStatusCode statusCode = this->parser_.parse(buffer.substr(res), curSession);
+		EnumStatusCode statusCode = this->parser_.parse(buffer.substr(0, res), curSession);
 		curSession.setErrorStatusCode(statusCode);
 
 		// 파싱이 끝나고 나서, 에러 status code와 RequestMessage의 상태를 점검함

--- a/src/EventHandler/EventHandlerSendResponse.cpp
+++ b/src/EventHandler/EventHandlerSendResponse.cpp
@@ -12,6 +12,9 @@ EnumSesStatus EventHandler::sendResponse(ClientSession& session) {
     std::string writeBuffer = session.getWriteBuffer();
     int clientFd = session.getClientFd();
 
+    // 송신한 내용 출력(로그용)
+    std::clog << "[Will Be Sent MSG]\n" << writeBuffer << std::endl;
+
     // 보낼 내용이 없으면 바로 완료 상태로 설정
     if (writeBuffer.empty()) {
         return WRITE_COMPLETE;

--- a/src/ServerManager/ServerManager.cpp
+++ b/src/ServerManager/ServerManager.cpp
@@ -51,6 +51,7 @@ void ServerManager::setupListeningSockets() {
         }
         // 현재 서버 구성을 해당 수신 소켓에 매핑합니다.
         // 이를 통해 여러 서버 구성이 동일한 소켓을 공유할 수 있습니다.
+        std::clog << "Connectected LISTENING SOCKET" << i+1 << " : " << sockFd << std::endl;
         globalConfig.listenFdToServers_[sockFd].push_back(&server);
     }
 }

--- a/src/ServerManager/ServerManagerRun.cpp
+++ b/src/ServerManager/ServerManagerRun.cpp
@@ -19,6 +19,7 @@ void ServerManager::run() {
 
 		while (isServerRunning()) {
 			// 발생한 이벤트의 개수를 확인
+			std::clog << "\n\n💬 Webserv Waiting For EVENTS..." << std::endl;
 			int	numEvents = reactor.waitForEvent();
 
 			// 발생한 각 이벤트를 순회하며 처리
@@ -31,15 +32,18 @@ void ServerManager::run() {
 					removeClientInfo(fd, clientManager, reactor, timeoutHandler);
 				} else if (type == READ_EVENT) {
 					if (isListeningSocket(fd)) {
+						std::clog << "READ Event on Listening Socket " << fd << std::endl;
 						// 리스닝 소켓에서 읽기 이벤트 발생: 새로운 클라이언트의 연결 요청 처리
 						processServerReadEvent(
 							fd, clientManager, eventHandler, timeoutHandler, reactor);
 					} else {
+						std::clog << "READ Event on Client Socket " << fd << std::endl;
 						// 기존 클라이언트 소켓에서 읽기 이벤트 발생: 클라이언트로부터 데이터 수신 처리
 						processClientReadEvent(
 							fd, clientManager, eventHandler, timeoutHandler, reactor);
 					}
 				} else if (type == WRITE_EVENT) {
+					std::clog << "WRITE Event on Client Socket " << fd << std::endl;
 					// 쓰기 이벤트 발생: 클라이언트에게 데이터를 전송하는 작업 처리
 					processClientWriteEvent(
 						fd, clientManager, eventHandler, timeoutHandler, reactor);
@@ -50,11 +54,11 @@ void ServerManager::run() {
 		}
 	} catch (std::exception& e) {
 	    // 예외 발생 시, 서버 비정상 종료에 대비하여 연결된 모든 클라이언트에게 종료 알림을 전송
-		notifyClientsShutdown(clientManager, eventHandler);
+		// notifyClientsShutdown(clientManager, eventHandler);
 		throw; // 원래 예외 그대로 throw
 	}
 	// 서버가 정상 종료된 시 모든 클라이언트에게 종료 알림 전송
-	notifyClientsShutdown(clientManager, eventHandler);
+	// notifyClientsShutdown(clientManager, eventHandler);
 }
 
 // 서버 종료 전에, 모든 클라이언트에게 종료 메시지(503:SERVICE_UNAVAILABLE)를 전송합니다.
@@ -84,6 +88,7 @@ void ServerManager::removeClientInfo(int clientFd, ClientManager& clientManager,
 	timeoutHandler.removeConnection(clientFd);
 	// 리액터에서 클라이언트 소켓 제거
 	reactor.removeSocket(clientFd);
+	std::clog << "  Removed Client Socket " << clientFd << std::endl;
 }
 
 // 리스닝 소켓에서 읽기 이벤트가 발생하면 새로운 클라이언트의 연결 요청을 처리합니다.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,6 +11,7 @@ int main(int argc, char** argv) {
 		return 1;
 	}
 	try {
+		std::clog << "Setting up Webserv..." << std::endl;
 		GlobalConfig::initGlobalConfig(argv[1]);
 		setupSignalHandlers();
 		ServerManager serverManager;


### PR DESCRIPTION
### FIX : Kqueue의 EVFILT_EXCEPT 감지 비활성화
사유 : macOS 내 OOB 데이터 처리의 불완전성 [참고: AsyncUnixTest::UrgentObserver spins forever on macOS 10.12 ](https://github.com/capnproto/capnproto/issues/374)
- 기존 OOB나 소켓 이상을 감지하기 위해 도입했던 EVFILT_EXCEPT가 실제 환경에서 무한정 발생하는 문제 발생
- 해당 이벤트 감지 비활성화 시 정상적인 이벤트 수신 가능
- OOB와 같은 예외 이벤트 처리의 필요성 파악 및 대체 방법 알아볼 예정

**기타 수정 사항**
- 로그 추가(매 루프 시작, 이벤트 발생 구분, 소켓 연결 및 제거 로그, 송수신 데이터 출력)
- graceful shutdown 임시 비활성화(notifyClientShutDown()) : 에러페이지 세팅 전까지
- 오타

### 🚨수정해야하는 내용🚨
(@hyuniverse , @taerakim , @seonseo , @nowead )
- 정상 리퀘스트를 보내도 BAD REQUEST 발생
- 에러페이지(config) 세팅 누락 + 해당 데이터에 접근하면서 seg fault 발생
- kqueue 타임아웃 값 설정(현상태로는 이벤트 발생시까지 무한 대기)
