### PR TITLE
Fix: Timeout 체크 주기 개선

### DIFF
--- a/src/ClientSession/ClientSession.cpp
+++ b/src/ClientSession/ClientSession.cpp
@@ -78,6 +78,7 @@ void ClientSession::setReadBuffer(const std::string &remainData) {
 
 void ClientSession::setWriteBuffer(const std::string &remainData) {
 	this->writeBuffer_ = remainData;
+	resetRequest();
 }
 
 RequestMessage &ClientSession::accessReqMsg() {

--- a/src/ClientSession/ClientSession.hpp
+++ b/src/ClientSession/ClientSession.hpp
@@ -30,7 +30,6 @@ class ClientSession {
 
 		RequestMessage			&accessReqMsg();
 		std::string				&accessReadBuffer();
-		void					resetRequest();
 		
 	private:
 		int						listenFd_;
@@ -41,6 +40,8 @@ class ClientSession {
 		std::string				readBuffer_;
 		std::string				writeBuffer_;
 		std::string				clientIP_;
+		
+		void					resetRequest();
 };
 
 #endif

--- a/src/Demultiplexer/DemultiplexerBase.hpp
+++ b/src/Demultiplexer/DemultiplexerBase.hpp
@@ -2,12 +2,14 @@
 #define DEMULTIPLEXER_BASE_HPP
 
 #include "../include/commonEnums.hpp"
+#include <time.h>
+
 static const int MAX_EVENT = 1024;
 
 template <typename Derived>
 class DemultiplexerBase {
 	public:
-		int			waitForEvent(); 
+		int			waitForEvent(timespec* timeout); 
 		void		addSocket(int fd);
 		void		removeSocket(int fd);
 		void		addWriteEvent(int fd);

--- a/src/Demultiplexer/DemultiplexerBase.tpp
+++ b/src/Demultiplexer/DemultiplexerBase.tpp
@@ -11,8 +11,8 @@ DemultiplexerBase<Derived>::~DemultiplexerBase() {
 }
 
 template <typename Derived>
-int DemultiplexerBase<Derived>::waitForEvent() {
-	return static_cast<Derived&>(*this).waitForEventImpl();
+int DemultiplexerBase<Derived>::waitForEvent(timespec* timeout) {
+	return static_cast<Derived&>(*this).waitForEventImpl(timeout);
 }
 
 template <typename Derived>

--- a/src/Demultiplexer/KqueueDemultiplexer.cpp
+++ b/src/Demultiplexer/KqueueDemultiplexer.cpp
@@ -24,14 +24,14 @@ KqueueDemultiplexer::~KqueueDemultiplexer() {
 }
 
 // 이벤트를 대기하는 함수 (kevent 호출)
-int KqueueDemultiplexer::waitForEventImpl() {
+int KqueueDemultiplexer::waitForEventImpl(timespec* timeout) {
 	// 변경된 이벤트가 없으면(numChanges == 0) NULL 전달
 	int numChanges = changedEvents_.size();
 	const struct kevent* changedEvents = numChanges ? &changedEvents_[0] : NULL;
 
 	// kevent 호출: 이벤트 감지
 	// 반환값 : 감지된 이벤트 개수
-	numEvents_ = kevent(kq_, changedEvents, numChanges, &eventList_[0], MAX_EVENT, nullptr);
+	numEvents_ = kevent(kq_, changedEvents, numChanges, &eventList_[0], MAX_EVENT, timeout);
 	if (numEvents_ == -1) {
 		webserv::throwSystemError("kevent", "Waiting for events", "KqueueDemultiplexer::waitForEventImpl"); // kevent 호출 실패
 	}

--- a/src/Demultiplexer/KqueueDemultiplexer.hpp
+++ b/src/Demultiplexer/KqueueDemultiplexer.hpp
@@ -6,12 +6,13 @@
 #include "DemultiplexerBase.hpp"
 #include <vector>
 #include <set>
+#include <time.h>
 
 class KqueueDemultiplexer : public DemultiplexerBase<KqueueDemultiplexer> {
 	public:
 		KqueueDemultiplexer(std::set<int>& listenFds);
 		~KqueueDemultiplexer();
-		int			waitForEventImpl();
+		int			waitForEventImpl(timespec* timeout);
 		void		addSocketImpl(int fd);
 		void		removeSocketImpl(int fd);
 		void		addWriteEventImpl(int fd);

--- a/src/EventHandler/EventHandler.cpp
+++ b/src/EventHandler/EventHandler.cpp
@@ -71,7 +71,6 @@ EnumSesStatus EventHandler::handleClientReadEvent(ClientSession& clientSession) 
         }
         // 생성된 응답 메시지를 클라이언트 세션의 쓰기 버퍼에 저장
         clientSession.setWriteBuffer(responseMsg);
-        clientSession.resetRequest();
         
         // 클라이언트에게 응답 전송을 시도하고, 전송 결과에 따라 상태 갱신
         status = sendResponse(clientSession);

--- a/src/EventHandler/EventHandler.cpp
+++ b/src/EventHandler/EventHandler.cpp
@@ -71,6 +71,7 @@ EnumSesStatus EventHandler::handleClientReadEvent(ClientSession& clientSession) 
         }
         // 생성된 응답 메시지를 클라이언트 세션의 쓰기 버퍼에 저장
         clientSession.setWriteBuffer(responseMsg);
+        clientSession.resetRequest();
         
         // 클라이언트에게 응답 전송을 시도하고, 전송 결과에 따라 상태 갱신
         status = sendResponse(clientSession);

--- a/src/ServerManager/ServerManager.cpp
+++ b/src/ServerManager/ServerManager.cpp
@@ -51,7 +51,7 @@ void ServerManager::setupListeningSockets() {
         }
         // 현재 서버 구성을 해당 수신 소켓에 매핑합니다.
         // 이를 통해 여러 서버 구성이 동일한 소켓을 공유할 수 있습니다.
-        std::clog << "Connectected LISTENING SOCKET" << i+1 << " : " << sockFd << std::endl;
+        std::clog << "Connected LISTENING SOCKET no." << i+1 << " : " << sockFd << std::endl;
         globalConfig.listenFdToServers_[sockFd].push_back(&server);
     }
 }

--- a/src/ServerManager/ServerManagerRun.cpp
+++ b/src/ServerManager/ServerManagerRun.cpp
@@ -20,7 +20,9 @@ void ServerManager::run() {
 		while (isServerRunning()) {
 			// 발생한 이벤트의 개수를 확인
 			std::clog << "\n\n💬 Webserv Waiting For EVENTS..." << std::endl;
-			int	numEvents = reactor.waitForEvent();
+
+			timespec* timeout = timeoutHandler.getEarliestTimeout();
+			int	numEvents = reactor.waitForEvent(timeout);
 
 			// 발생한 각 이벤트를 순회하며 처리
 			for (int i = 0; i < numEvents; ++i) {

--- a/src/TimeoutHandler/TimeoutHandler.hpp
+++ b/src/TimeoutHandler/TimeoutHandler.hpp
@@ -19,12 +19,14 @@ class TimeoutHandler {
         TimeoutHandler();
         ~TimeoutHandler();
 
-        void addConnection(int fd);
-        void updateActivity(int fd);
-        void checkTimeouts(EventHandler& eventHandler, Demultiplexer& reactor, ClientManager& clientManager);
-        void removeConnection(int fd);
+        timespec*   getEarliestTimeout();
+        void        addConnection(int fd);
+        void        updateActivity(int fd);
+        void        checkTimeouts(EventHandler& eventHandler, Demultiplexer& reactor, ClientManager& clientManager);
+        void        removeConnection(int fd);
 
     private:
+        timespec                    timeout_;
         std::map<int, time_t>       connections_; // 연결 정보 (fd -> 마지막 활동 시간)
         std::multimap<time_t, int>  expireQueue_; // 만료 시간 기준으로 오름차순 정렬된 연결 목록
         TypeExpireIterMap           expireMap_;   // fd -> expireQueue_의 iterator


### PR DESCRIPTION
### 기존
항시 무한정 대기: timeout값에 nullptr 넘김

### 목표
if 연결된 클라이언트 존재 : 가장 임박한 만료시간까지 대기 
else : 기존처럼 대기

### 변경 사항
**(1) TimeoutHandler 내 임박한 만료시간 관리 및 getter 생성
(2) 제공된 만료시간 정보를 타임아웃 주기에 반영**