### PR TITLE
refactor: reqConfig, reqMsg 접근방법 수정

### DIFF
--- a/src/ClientSession/ClientSession.cpp
+++ b/src/ClientSession/ClientSession.cpp
@@ -6,6 +6,7 @@
 
 ClientSession::ClientSession(int listenFd, int clientFd, std::string clientIP) : listenFd_(listenFd), clientFd_(clientFd), reqMsg_(NULL), config_(NULL), clientIP_(clientIP) {
 	this->readBuffer_.reserve(BUFFER_SIZE * 2);
+	this->defConfig_ = GlobalConfig::findRequestConfig(listenFd, "", "");
 }
 ClientSession::~ClientSession() {
 	if (this->reqMsg_ != NULL)
@@ -24,20 +25,15 @@ int ClientSession::getErrorStatusCode() const {
 	return this->errorStatusCode_;
 }
 
-const RequestMessage &ClientSession::getReqMsg() const {
-	return *this->reqMsg_;
-}
-
-const RequestConfig &ClientSession::getConfig() const {
-	return *this->config_;
-}
-
-const RequestMessage *ClientSession::getReqMsgPtr() const {
+const RequestMessage *ClientSession::getReqMsg() const {
 	return this->reqMsg_;
 }
 
-const RequestConfig *ClientSession::getConfigPtr() const {
-	return this->config_;
+const RequestConfig *ClientSession::getConfig() const {
+	if (config_) {
+		return this->config_;
+	}
+	return this->defConfig_;
 }
 
 std::string ClientSession::getReadBuffer() const {

--- a/src/ClientSession/ClientSession.hpp
+++ b/src/ClientSession/ClientSession.hpp
@@ -13,10 +13,8 @@ class ClientSession {
 		int						getListenFd() const;
 		int						getClientFd() const;
 		int						getErrorStatusCode() const;
-		const RequestMessage	&getReqMsg() const;
-		const RequestConfig		&getConfig() const;
-		const RequestMessage	*getReqMsgPtr() const;
-		const RequestConfig		*getConfigPtr() const;
+		const RequestMessage	*getReqMsg() const;
+		const RequestConfig		*getConfig() const;
 		std::string				getReadBuffer() const;
 		std::string				getWriteBuffer() const;
 		std::string				getClientIP() const;
@@ -38,6 +36,7 @@ class ClientSession {
 		int						errorStatusCode_;
 		RequestMessage			*reqMsg_;
 		const RequestConfig		*config_;
+		const RequestConfig		*defConfig_;
 		std::string				readBuffer_;
 		std::string				writeBuffer_;
 		std::string				clientIP_;

--- a/src/EventHandler/EventHandler.cpp
+++ b/src/EventHandler/EventHandler.cpp
@@ -57,9 +57,9 @@ EnumSesStatus EventHandler::handleClientReadEvent(ClientSession& clientSession) 
 
     if (status == READ_COMPLETE) {
         // 요청 데이터 수신이 완료된 경우
-        RequestMessage  requestMsg = clientSession.getReqMsg();
+        RequestMessage  &requestMsg = *clientSession.getReqMsg();
         std::string     responseMsg;
-		const RequestConfig&	reqConfig = clientSession.getConfig();
+		const RequestConfig&	reqConfig = *clientSession.getConfig();
 
         // 요청 URI에 CGI 실행 대상이 포함되어 있는지 확인
         if (cgiHandler_.isCGI(requestMsg.getTargetURI(), reqConfig.cgiExtension_)) {
@@ -102,7 +102,7 @@ EnumSesStatus EventHandler::handleClientWriteEvent(ClientSession& clientSession)
 //---------------------------------------------------------------------
 void EventHandler::handleError(int statusCode, ClientSession& clientSession) {
     // ResponseBuilder를 사용하여 상태 코드에 맞는 에러 응답 메시지 생성
-    std::string errorMsg = rspBuilder_.buildError(statusCode, clientSession.getConfig());
+    std::string errorMsg = rspBuilder_.buildError(statusCode, *clientSession.getConfig());
 
     // 생성된 에러 메시지를 클라이언트 세션의 쓰기 버퍼에 저장
     clientSession.setWriteBuffer(errorMsg);

--- a/src/EventHandler/EventHandlerRecvRequest.cpp
+++ b/src/EventHandler/EventHandlerRecvRequest.cpp
@@ -36,7 +36,7 @@ EnumSesStatus EventHandler::recvRequest(ClientSession &curSession) {
 		std::clog << "[Received MSG]\n" << buffer << std::endl;
 
 		// 해당 ClientSession의 RequestMessage를 파싱하기 전에 Body의 최대 길이를 설정
-		const RequestConfig *config = curSession.getConfigPtr();
+		const RequestConfig *config = curSession.getConfig();
 		const size_t bodyMax = (config == NULL) ? BODY_MAX_LENGTH : config->clientMaxBodySize_.value();
 		this->parser_.setConfigBodyLength(bodyMax);
 
@@ -48,14 +48,14 @@ EnumSesStatus EventHandler::recvRequest(ClientSession &curSession) {
 		EnumSesStatus result;
 		if (curSession.getErrorStatusCode() != NONE_STATUS_CODE)
 			result = REQUEST_ERROR;
-		else if (curSession.getReqMsgPtr()->getStatus() == REQ_DONE)
+		else if (curSession.getReqMsg()->getStatus() == REQ_DONE)
 			result = READ_COMPLETE;
 		else
 			result = READ_CONTINUE;
 
 		// 파싱이 완전히 종료되는 경우에 Config 누락 방지
 		if ((result == READ_COMPLETE || result == REQUEST_ERROR)
-		&& curSession.getConfigPtr() == NULL) {
+		&& curSession.getConfig() == NULL) {
 			const GlobalConfig &globalConfig = GlobalConfig::getInstance();
 			curSession.setConfig(globalConfig.findRequestConfig(curSession.getListenFd(), curSession.accessReqMsg().getMetaHost(), curSession.accessReqMsg().getTargetURI()));
 		}

--- a/src/RequestHandler/CgiHandler.cpp
+++ b/src/RequestHandler/CgiHandler.cpp
@@ -34,8 +34,8 @@ bool CgiHandler::isCGI(const std::string& targetUri, const std::string& cgiExten
 // 클라이언트의 요청을 처리하여 CGI 결과를 반환하는 함수
 std::string CgiHandler::handleRequest(const ClientSession& clientSession) {
     // 클라이언트 요청 메시지와 설정 정보 가져옴
-    const RequestMessage& reqMsg = clientSession.getReqMsg();
-    const RequestConfig& conf = clientSession.getConfig();
+    const RequestMessage& reqMsg = *clientSession.getReqMsg();
+    const RequestConfig& conf = *clientSession.getConfig();
 
     // URI를 파싱하여 스크립트 경로, 쿼리 문자열 등 추출
     UriParts parts = parseUri(conf.root_, reqMsg.getTargetURI());
@@ -67,8 +67,8 @@ void CgiHandler::buildCgiEnv(const ClientSession& clientSession,
     // HTTP 메서드를 문자열로 변환하기 위한 배열
     static const std::string methodStrings[] = {"NONE", "GET", "POST", "DELETE"};
     // 클라이언트 요청 메시지와 설정 정보를 가져옴
-    const RequestMessage& reqMsg = clientSession.getReqMsg();
-    const RequestConfig& conf = clientSession.getConfig();
+    const RequestMessage& reqMsg = *clientSession.getReqMsg();
+    const RequestConfig& conf = *clientSession.getConfig();
 
     envVars.reserve(11);               // 아래 설정할 변수 수만큼 벡터 공간 예약
     envVars.push_back(makeEnvVar("GATEWAY_INTERFACE", "CGI/1.1"));  // CGI 인터페이스 버전 설정

--- a/src/RequestParser/RequestParser.cpp
+++ b/src/RequestParser/RequestParser.cpp
@@ -19,7 +19,7 @@ void RequestParser::setConfigBodyLength(size_t length) {
 //     readCursor_: 버퍼의 마지막 위치를 기록
 EnumStatusCode RequestParser::parse(const std::string &readData, ClientSession &curSession) {
 	// 새로운 요청일 때, RequestMessage 동적할당
-	if (curSession.getReqMsgPtr() == NULL)
+	if (curSession.getReqMsg() == NULL)
 		curSession.setReqMsg(new RequestMessage());// 이후 요청처리(handler&builder) 완료 후, delete 필요 (ClientSession.resetRequest()메서드 사용)
 
 	RequestMessage &reqMsg = curSession.accessReqMsg();


### PR DESCRIPTION
- ClientSession::getConfigPtr()를 getConfig()로 통합
- ClientSession::getReqMsgPtr()를 getReqMsg()로 통합
config_와 reqMsg_는 값이 있을지 없을지 모르는 멤버 변수이기 때문에,
레퍼런스로 접근하는 것은 바람직하지 않음.
- ClientSession::defConfig_ 추가
config_의 값이 계속해서 변하기 때문에, 변하지 않는 기본값을 저장할 멤버 변수
생성자에서 설정되기 때문에 항상 변하지 않는 값을 보장함
- config_의 값이 없을 시 getConfig()에서 defConfig_를 반환하도록 수정