### PR TITLE
build: Makefile  로그 단순화한 기능 추가 및 기본으로 설정

### DIFF
--- a/include_make/Link.mk
+++ b/include_make/Link.mk
@@ -1,8 +1,8 @@
 link_files::
 	@mkdir -p $(dst_dir);
-	$(Q)$(foreach file,$(files), $(call color_printf,$(CYAN),$(file),🔗 linking file\n)ln -sf $(src_dir)/$(file) $(dst_dir);)
+	$(Q)$(foreach file,$(files), $(call $(AQ_color_printf),$(CYAN),$(file),🔗 linking file\n)ln -sf $(src_dir)/$(file) $(dst_dir);)
 	$(Q)$(foreach file,$(files), ln -sf $(src_dir)/$(file) $(dst_dir)/$(file);)
 
 unlink_files::
-	$(Q)$(foreach file,$(files), $(call color_printf,$(GRAY),$(file),🚫 unlinking file\n)$(RM) $(dst_dir)/$(file);)
+	$(Q)$(foreach file,$(files), $(call $(AQ_color_printf),$(GRAY),$(file),🚫 unlinking file\n)$(RM) $(dst_dir)/$(file);)
 	$(Q)$(foreach file,$(files), $(RM) $(dst_dir)/$(file);)

--- a/include_make/Recipe_src.mk
+++ b/include_make/Recipe_src.mk
@@ -1,7 +1,11 @@
 all:
+	$(Q)$(call color_printf,$(BLUE),$(NAME),✨ starting compile $(NAME))
 	$(Q)$(foreach dir,$(DIRS),$(MAKE) TOPDIR=$(TOPDIR) SRCDIR=`pwd` -C $(dir) $@;)
 	$(Q)$(MAKE) $(NAME)
 	$(Q)$(call color_printf,$(BOLD_PURPLE),$(NAME),✨ compiled!)
+
+%.o: %.cpp
+	$(AQ)$(COMPILE.cpp) $(OUTPUT_OPTION) $<
 
 $(NAME): $(OBJS) $(SUBS)
 	$(Q)$(LINK.cpp) $^ $(LOADLIBES) $(LDLIBS) -o $@

--- a/include_make/Recipe_subsrc.mk
+++ b/include_make/Recipe_subsrc.mk
@@ -1,10 +1,13 @@
 all: 
-	$(Q)$(call color_printf,$(YELLOW),$(NAME),🎯 starting compile $(NAME))
+	$(Q)$(call $(AQ_color_printf),$(YELLOW),$(NAME),🎯 starting compile $(NAME))
 	$(Q)$(MAKE) $(NAME)
-	$(Q)$(call color_printf,$(BLUE),$(NAME),🔰 done!)
+	$(Q)$(call $(AQ_color_printf),$(BLUE),$(NAME),🔰 done!)
+
+%.o: %.cpp
+	$(AQ)$(COMPILE.cpp) $(OUTPUT_OPTION) $<
 
 $(NAME): $(OBJS)
-	$(Q)$(call color_printf,$(GREEN),$(NAME),📚 archive object)
+	$(Q)$(call $(AQ_color_printf),$(GREEN),$(NAME),📚 archive object)
 	$(Q)$(AR) $(ARFLAGS) $@ $^
 	$(Q)$(MAKE) files=$(NAME) src_dir=`pwd` dst_dir=$(SRCDIR) link_files
 	$(Q)$(foreach head,$(HEAD), $(MAKE) files=$(head) src_dir=`pwd` dst_dir=$(SRCDIR)/include link_files;)
@@ -12,7 +15,7 @@ $(NAME): $(OBJS)
 clean:
 	$(Q)$(MAKE) files=$(NAME) src_dir=`pwd` dst_dir=$(SRCDIR) unlink_files
 	$(Q)$(foreach head,$(HEAD), $(MAKE) files=$(head) src_dir=`pwd` dst_dir=$(SRCDIR)/include unlink_files;)
-	$(Q)$(Q)$(call color_printf,$(RED),$(NAME),🗑️  remove Objects && Dependency file)
+	$(Q)$(Q)$(call $(AQ_color_printf),$(RED),$(NAME),🗑️  remove Objects && Dependency file)
 	$(Q)$(RM) $(OBJS) $(DEPS)
 	$(Q)$(RM) $(NAME)
 

--- a/include_make/Verbose.mk
+++ b/include_make/Verbose.mk
@@ -1,2 +1,6 @@
+# all verbose
+AQ := $(if $(filter 1,$(NOTALL)),,@)
+AQ_color_printf := $(if $(filter @,$(AQ)),,color_printf)
+
 # verbose
 Q := $(if $(filter 1,$(V) $(VERBOSE)),,@)


### PR DESCRIPTION
## 구현
1. 로그 단순화 기능 추가
2. 로그 단순화를 default로 설정
3. 기존의 컬러타이틀 방식은 `NOTALL`변수 설정으로 가능

---
## 참고 이미지
1. 새로운 로그 `$make`
<img width="453" alt="Image" src="https://github.com/user-attachments/assets/72043de3-0a9e-4d0f-80d4-b0ca9ab2a380" />

2. 기존의 로그 `$make NOTALL=1`
<img width="500" alt="Image" src="https://github.com/user-attachments/assets/042068b8-6339-4b22-81d7-81079eb0aac7" />