### PR TITLE
chore: evfilt_except 관련 내용 제거, handleError 호출 활성화

### DIFF
--- a/src/Demultiplexer/KqueueDemultiplexer.cpp
+++ b/src/Demultiplexer/KqueueDemultiplexer.cpp
@@ -82,9 +82,6 @@ EnumEvent KqueueDemultiplexer::getEventTypeImpl(int idx) {
 		if (eventList_[idx].filter == EVFILT_WRITE) {
 			return WRITE_EVENT; // 쓰기 이벤트
 		}
-		if (eventList_[idx].filter == EVFILT_EXCEPT) {
-			return EXCEPTION_EVENT; // 예외 이벤트
-		}
 	}
 	return UNKNOWN_EVENT; // 알 수 없는 이벤트
 }

--- a/src/ServerManager/ServerManagerRun.cpp
+++ b/src/ServerManager/ServerManagerRun.cpp
@@ -29,10 +29,7 @@ void ServerManager::run() {
 				EnumEvent	type = reactor.getEventType(i);
 				int 		fd = reactor.getSocketFd(i);
 
-				if (type == EXCEPTION_EVENT) {
-					// 예외 이벤트 발생: 소켓 오류 등으로 인해 클라이언트 연결을 종료
-					removeClientInfo(fd, clientManager, reactor, timeoutHandler);
-				} else if (type == READ_EVENT) {
+				if (type == READ_EVENT) {
 					if (isListeningSocket(fd)) {
 						std::clog << "READ Event on Listening Socket " << fd << std::endl;
 						// 리스닝 소켓에서 읽기 이벤트 발생: 새로운 클라이언트의 연결 요청 처리
@@ -56,11 +53,11 @@ void ServerManager::run() {
 		}
 	} catch (std::exception& e) {
 	    // 예외 발생 시, 서버 비정상 종료에 대비하여 연결된 모든 클라이언트에게 종료 알림을 전송
-		// notifyClientsShutdown(clientManager, eventHandler);
+		notifyClientsShutdown(clientManager, eventHandler);
 		throw; // 원래 예외 그대로 throw
 	}
 	// 서버가 정상 종료된 시 모든 클라이언트에게 종료 알림 전송
-	// notifyClientsShutdown(clientManager, eventHandler);
+	notifyClientsShutdown(clientManager, eventHandler);
 }
 
 // 서버 종료 전에, 모든 클라이언트에게 종료 메시지(503:SERVICE_UNAVAILABLE)를 전송합니다.

--- a/src/TimeoutHandler/TimeoutHandler.cpp
+++ b/src/TimeoutHandler/TimeoutHandler.cpp
@@ -84,8 +84,6 @@ void TimeoutHandler::checkTimeouts(EventHandler& eventHandler, Demultiplexer& re
         } else {
             // HTTP 408 Request Timeout 처리
             eventHandler.handleError(408, *client);
-            // config 접근시 터지는 문제로, 테스트시 위를 주석처리, 아래를 주석해제
-            //(void)eventHandler;
         }
 
         // client 정보 삭제 및 정리

--- a/src/include/commonEnums.hpp
+++ b/src/include/commonEnums.hpp
@@ -13,7 +13,6 @@ typedef enum EnumSessionStatus {
 enum EnumEvent {
 	READ_EVENT,
 	WRITE_EVENT,
-	EXCEPTION_EVENT,
 	UNKNOWN_EVENT
 };
 


### PR DESCRIPTION
커밋 : a4c4788

기존 OOB 감지를 위해 지원했던  `EVFILT_EXCEPT`는 버그 발생으로 '감지 자체만' 비활성화했습니다.
아직 곳곳에 예외 이벤트 감지 시 처리 로직은 남아있는 상태입니다.
해당 로직들의 처분을 판단하기 위해, 해당 필터가 지원하던 기능이 웹서버에 필수적인지 알아보았습니다.
그 결과 필수적인 기능은 아니며, I/O 처리 시 에러 처리를 해주는 것으로 충분하다는 결론입니다.
따라서 남아있는 로직들을 제거합니다.