### PR TITLE
fix: Idle Timeout과 Request Timeout 구분

### DIFF
--- a/src/ClientSession/ClientSession.cpp
+++ b/src/ClientSession/ClientSession.cpp
@@ -77,6 +77,13 @@ void ClientSession::setWriteBuffer(const std::string &remainData) {
 	resetRequest();
 }
 
+bool ClientSession::isReceiving() const {
+	if (this->reqMsg_) {
+		return true;
+	}
+	return false;
+}
+
 RequestMessage &ClientSession::accessReqMsg() {
 	return *this->reqMsg_;
 }

--- a/src/ClientSession/ClientSession.hpp
+++ b/src/ClientSession/ClientSession.hpp
@@ -25,6 +25,7 @@ class ClientSession {
 		void					setConfig(const RequestConfig *config);
 		void					setReadBuffer(const std::string &remainData);
 		void					setWriteBuffer(const std::string &remainData);
+		bool					isReceiving() const;
 
 		RequestMessage			&accessReqMsg();
 		std::string				&accessReadBuffer();

--- a/src/ServerManager/ServerManagerRun.cpp
+++ b/src/ServerManager/ServerManagerRun.cpp
@@ -122,15 +122,11 @@ void ServerManager::processClientReadEvent(int fd, ClientManager& clientManager,
 	if (status == CONNECTION_CLOSED) { 
 		// 클라이언트가 연결을 종료한 경우, 관련 정보를 삭제
 		removeClientInfo(fd, clientManager, reactor, timeoutHandler);
-	} else if (status == WRITE_CONTINUE) { 
-		// 추가적인 쓰기 작업이 필요한 경우:
-		// - 타임아웃을 갱신
-		// - 해당 클라이언트에 대해 쓰기 이벤트를 추가
-		timeoutHandler.updateActivity(fd);
-		reactor.addWriteEvent(fd);
-	} else { 
-		// 그 외, 타임아웃만 갱신
-		timeoutHandler.updateActivity(fd);
+	} else {
+		timeoutHandler.updateActivity(fd, status);
+		if (status == WRITE_CONTINUE) {
+			reactor.addWriteEvent(fd);
+		}
 	}
 }
 

--- a/src/TimeoutHandler/TimeoutHandler.hpp
+++ b/src/TimeoutHandler/TimeoutHandler.hpp
@@ -6,8 +6,8 @@
 #include "../ClientManager/ClientManager.hpp"
 #include <map>
 
-// Nginx의 client_body_timeout 값과 동일 (초 단위 제한 시간)
-static const int LIMIT = 60;
+static const int REQ_LIMIT = 15;
+static const int IDLE_LIMIT = 30;
 
 class TimeoutHandler {
     public:
@@ -21,7 +21,7 @@ class TimeoutHandler {
 
         timespec*   getEarliestTimeout();
         void        addConnection(int fd);
-        void        updateActivity(int fd);
+        void        updateActivity(int fd, EnumSesStatus status);
         void        checkTimeouts(EventHandler& eventHandler, Demultiplexer& reactor, ClientManager& clientManager);
         void        removeConnection(int fd);
 


### PR DESCRIPTION
## 기존 webserv 타임아웃 처리의 문제점 (2025.02.27 기준)
: Idle과 요청 진행 시의 상황을 구분하지 않아, 정상적으로 웹페이지를 보던 클라이언트도 408에러를 수신하게 됨.
  즉, Idle의 타임아웃 상황에 요청 타임아웃 결과를 반환

## 변경 사항
**1. ClientSession 내 isReceiving() 판별메소드 추가**
- 목적: 클라이언트가 요청을 수신 중에 있는지, 요청 수신을 완료되었는지 판별
- 구현 방법: reqMsg_ 멤버변수가  null일 경우 수신완료, 아닐경우 수신 중
- 근거: 요청 수신 완료시 필연적으로 setWriteBuffer()를 호출하여 readMsg를 초기화하게 되어있음. 따라서 수신 완료시 null임이 보장 됨. 

**2. Idle 상태와 Request 처리에서의 Timeout 구분**

| 항목                | Idle 상태      | 요청 수신 중                                   |
|---------------------|----------------|------------------------------------------------|
| 만료 시각 갱신 기준 | `IDLE_TIMEOUT` |                  `REQ_TIMEOUT`                 |
| 만료 시 처리        | 리소스만 정리  | 클라이언트에 408 에러 반환 시도 후 리소스 정리 | |

- TimeoutHandler.updateTimeout() : 상태구분을 위한 파라미터 추가, 파라미터에 따른 만료시각 갱신 값 구분
- TimeoutHandler.checkTimeout() : clientSession.isReceiving() == true일 경우 408 반환, 아닐 경우 리소스만 정리
- ServerManager.processClientReadEvent() 내 변경사항 적용 및 중복 로직 정리


### 추가: 연결 지연 테스트 방법
unix환경의 경우 nc(netcat) 사용
```
nc localhost 8080
```
위 명령어로 웹서버와 연결 후 `ctrl+j`(LF) 혹은 `ctrl+m`(CR) 입력할 경우 서버는 요청을 기다리는 상태가 됨. 