### PR TITLE
fix: signal 종료 시 error 출력 비활성화(#186)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,7 +19,9 @@ int main(int argc, char** argv) {
 		serverManager.run();
 	} catch (const std::exception& e) {
 		GlobalConfig::destroyInstance();
-		std::cerr << "Error: " << e.what() << std::endl;
+		if (globalServerRunning) {
+			std::cerr << "Error: " << e.what() << std::endl;
+		}
 		return 1;
 	}
 	GlobalConfig::destroyInstance();


### PR DESCRIPTION
signal 종료 시 globalServerRunning 값이 false로 바뀝니다. 
이를 이용해 signal 종료 여부를 판단후, 해당하지 않을 경우에만 에러로그 출력하도록 수정했습니다!(main.cpp)