### PR TITLE
docs: 커밋 메시지 가이드라인 업데이트 및 CLAUDE.md 관리 설정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ modules.order
 Module.symvers
 Mkfile.old
 dkms.conf
+
+# Claude AI configuration file - keep local to persist across branches
+CLAUDE.md

--- a/.gitmessage.txt
+++ b/.gitmessage.txt
@@ -1,8 +1,8 @@
-# \<type>: \<subject>
+# \<type>: \<subject> - 한국어로 작성
 ##### Subject 50 characters ################# -> |
  
  
-# Body Message
+# Body Message - 한국어로 작성
 ######## Body 72 characters ####################################### -> |
  
 # Issue Tracker Number or URL
@@ -21,10 +21,15 @@
 #             프로덕션 코드 변경 없음
 # ------------------
 # Commit rules:
+#   커밋 메시지는 한국어로 작성합니다
 #   subject 대문자 사용 (Capitalize)
 #   subject에 명령형 분위기 사용
 #   subject을 마침표로 끝내지 않기
 #   빈 줄로 subject와 body을 구분합니다.
 #   body을 사용하여 '무엇'과 '왜', '어떻게'를 설명합니다.
-#   body에서 글머리 기호에 “-”로 여러 줄 사용 가능
+#   body에서 글머리 기호에 "-"로 여러 줄 사용 가능
 # ------------------
+# 
+# 예시:
+# feat: 클라이언트 세션 타임아웃 처리 추가
+# fix: 멀티스레드 환경에서 발생하는 데드락 문제 해결


### PR DESCRIPTION
- 커밋 메시지 작성 시 한국어로 작성하도록 안내 추가
- 커밋 메시지 예시 추가
- CLAUDE.md 파일을 .gitignore에 추가하여 브랜치 간 유지되도록 설정