### PR TITLE
fix: ubuntu 환경에서 kqueue라이브러리 인식하도록 수정 및 기타(#194)

### DIFF
--- a/include_make/Variable.mk
+++ b/include_make/Variable.mk
@@ -3,7 +3,7 @@
 
 CXXFLAGS = -Wall -Wextra -Werror -std=c++98
 ARFLAGS = rcs
-CPPFLAGS = $(shell find $(SRCDIR) -type d | sort -u | sed 's|^|-I|')
+CPPFLAGS = $(shell find $(SRCDIR) -type d | sort -u | sed 's|^|-I|') -I/usr/include/kqueue/
 # src경로의 모든 디렉토리를 include path로 추가
 
 OBJS = $(SRCS:.cpp=.o)

--- a/src/Demultiplexer/KqueueDemultiplexer.cpp
+++ b/src/Demultiplexer/KqueueDemultiplexer.cpp
@@ -44,7 +44,7 @@ int KqueueDemultiplexer::waitForEventImpl(timespec* timeout) {
 void KqueueDemultiplexer::addSocketImpl(int fd) {
 	struct kevent change;
 
-	EV_SET(&change, fd, EVFILT_READ, EV_ADD, 0, 0, nullptr);
+	EV_SET(&change, fd, EVFILT_READ, EV_ADD, 0, 0, NULL);
 	changedEvents_.push_back(change);
 }
 
@@ -52,8 +52,8 @@ void KqueueDemultiplexer::addSocketImpl(int fd) {
 void KqueueDemultiplexer::removeSocketImpl(int fd) {
 	struct kevent changes[2];
 
-	EV_SET(&changes[0], fd, EVFILT_READ, EV_DELETE, 0, 0, nullptr);   // 읽기 이벤트 제거
-	EV_SET(&changes[1], fd, EVFILT_WRITE, EV_DELETE, 0, 0, nullptr);  // 쓰기 이벤트 제거
+	EV_SET(&changes[0], fd, EVFILT_READ, EV_DELETE, 0, 0, NULL);   // 읽기 이벤트 제거
+	EV_SET(&changes[1], fd, EVFILT_WRITE, EV_DELETE, 0, 0, NULL);  // 쓰기 이벤트 제거
 	changedEvents_.insert(changedEvents_.end(), changes, changes + 2);
 }
 
@@ -61,7 +61,7 @@ void KqueueDemultiplexer::removeSocketImpl(int fd) {
 void KqueueDemultiplexer::addWriteEventImpl(int fd) {
 	struct kevent change;
 
-	EV_SET(&change, fd, EVFILT_WRITE, EV_ADD, 0, 0, nullptr);
+	EV_SET(&change, fd, EVFILT_WRITE, EV_ADD, 0, 0, NULL);
 	changedEvents_.push_back(change);
 }
 
@@ -69,7 +69,7 @@ void KqueueDemultiplexer::addWriteEventImpl(int fd) {
 void KqueueDemultiplexer::removeWriteEventImpl(int fd) {
 	struct kevent change;
 	
-	EV_SET(&change, fd, EVFILT_WRITE, EV_DELETE, 0, 0, nullptr);
+	EV_SET(&change, fd, EVFILT_WRITE, EV_DELETE, 0, 0, NULL);
 	changedEvents_.push_back(change);
 }
 

--- a/src/Demultiplexer/KqueueDemultiplexer.hpp
+++ b/src/Demultiplexer/KqueueDemultiplexer.hpp
@@ -1,7 +1,7 @@
 #ifndef KQUEUE_DEMULTIPLEXER_HPP
 #define KQUEUE_DEMULTIPLEXER_HPP
 
-#ifdef __APPLE__
+// #ifdef __APPLE__
 
 #include "DemultiplexerBase.hpp"
 #include <vector>
@@ -31,5 +31,5 @@ class KqueueDemultiplexer : public DemultiplexerBase<KqueueDemultiplexer> {
 
 typedef KqueueDemultiplexer Demultiplexer;
 
-#endif
+// #endif
 #endif


### PR DESCRIPTION
kqueue 라이브러리 인식하도록 variable.mk 수정
c++98에서 지원하지 않는 nullptr -> NULL로 수정
mac환경에서 사용되도록 제한해두 #ifdef __APPLE #endif 주석처리