### PR TITLE
feat: 42테스터를 위한 컨테이너 환경 준비

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ src/manda/include/*
 test*
 .DS_Store
 .vscode/
+# (3)tester
+ubuntu_tester
 
 # Prerequisites
 *.d

--- a/42tester.mk
+++ b/42tester.mk
@@ -1,22 +1,27 @@
-IMAGE_NAME = webserv
-CONTAINER_NAME = webserv
+IMAGE_NAME		= webserv
+CONTAINER_NAME	= webserv
+PORT_HOST		= 8080
+PORT_CONTAINER	= 8080
 
-test:
-	docker build -t $(IMAGE_NAME) .
+tgo:
+	docker exec -it $(CONTAINER_NAME) /bin/bash
+
+t: ubuntu_tester
+	docker build --platform=linux/amd64 -t $(IMAGE_NAME) .
 #   이미 동일 이름의 컨테이너가 있으면 중지 후 제거
 	@docker stop $(CONTAINER_NAME) 2&>/dev/null || true
 	@docker rm $(CONTAINER_NAME) 2&>/dev/null || true
 #   새로 컨테이너 실행
-	docker run --name $(CONTAINER_NAME) -d $(IMAGE_NAME)
+	docker run --platform=linux/amd64 -p $(PORT_HOST):$(PORT_CONTAINER) --name $(CONTAINER_NAME) -d $(IMAGE_NAME)
 
-test_log:
+tlog:
 	docker logs $(CONTAINER_NAME)
 
-test_re:
-	@$(MAKE) test_clean
-	@$(MAKE) test
+tre:
+	@$(MAKE) tclean
+	@$(MAKE) t
 
-test_clean:
+tclean:
 	docker stop $(CONTAINER_NAME) 2&>/dev/null || true
 	docker rm $(CONTAINER_NAME) 2&>/dev/null || true
 	docker image rm -f $(IMAGE_NAME) 2&>/dev/null || true

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,8 @@ WORKDIR /app
 
 COPY . .
 
-CMD [ "sh", "-c", "make && ./webserv ./config/42tester.conf && make fclean" ]
+ENV TESTER="./ubuntu_tester http://localhost:8080"
+ENV SERVER="./webserv config/42tester.conf"
+
+ENTRYPOINT [ "sh", "-c", "make && make clean" ]
+CMD [ "tail", "-f", "/dev/null" ]

--- a/config/42tester.conf
+++ b/config/42tester.conf
@@ -1,4 +1,4 @@
-server { # php/fastcgi
+server {
 	listen       80;
 	server_name  localhost;
 	root         ./var/www/YoupiBanane;
@@ -8,37 +8,19 @@ server { # php/fastcgi
     location / {
 		autoindex   on;
 		error_page 404 405 /nop/youpi.bad_extension;
-		limit_except GET {
-			deny all;
-		}
+		methods GET
 	}
 
 	location /put_test {
-	    upload_store upload_put;
+	    upload_path upload_put;
 	}
 
 	location /post_body {
         client_max_body_size 100;
-        upload_store upload_post;
+        upload_path upload_post;
 	}
 
-	location /.bla {
-	    cgi_pass /cgi_tester;
-	}
-
-	location /.py {
-	    cgi_pass /CGI_2.py;
-      limit_except GET {
-        deny all;
-      }
-	}
-
-	location /.php {
-	    cgi_pass /CGI_1.php;
-      limit_except POST {
-        deny all;
-      }
-	}
+    cgi_extension .php;
 
 	location /directory {
 	    index          youpi.bad_extension;
@@ -70,21 +52,17 @@ server { # php/fastcgi
 
 	location /fileupload {
 		root         ./var/www;
-		upload_store upload;
+		upload_path upload;
 	}
 
-    location /cgi {
-      cgi_pass       /cgi_tester;
-    }
+    cgi_extension .php;
 
     location /delete {
         root        ./var/www/upload;
     }
 
     location /redirecturl {
-        limit_except GET POST HEAD {
-			deny all;
-		}
+        methods GET POST HEAD
 		autoindex off;
 		return 302 https://google.com;
 	}


### PR DESCRIPTION
## 수정
- `42tester.conf`

## 사용방법
1. 과제 페이지에서 ubuntu_tester를 다운받아 `./`경로에 준비한다.
2. $`make t`로 컨테이너를 준비하고 실행한다.
3. 터미널 두 개를 켜 `$make tgo`로 컨테이너에 접속한 다음, 각각 $TESTER, $SERVER 를 실행한다.