### PR TITLE
fix: isCGI함수에서 확장자 검사 방식 변경 compare -> find

### DIFF
--- a/src/RequestHandler/CgiHandler.cpp
+++ b/src/RequestHandler/CgiHandler.cpp
@@ -32,7 +32,7 @@ bool CgiHandler::isCGI(const std::string& targetUri, const std::string& cgiExten
     if (uriWithoutQuery.size() < cgiExtension.size()) {
         return false;
     }
-    return uriWithoutQuery.compare(uriWithoutQuery.size() - cgiExtension.size(), cgiExtension.size(), cgiExtension) == 0;
+    return uriWithoutQuery.find(cgiExtension, uriWithoutQuery.size() - cgiExtension.size()) == std::string::npos;
 }
 
 // 클라이언트의 요청을 처리하여 CGI 결과를 반환하는 함수


### PR DESCRIPTION
### 기존 방법 compare
`return uriWithoutQuery.compare(uriWithoutQuery.size() - cgiExtension.size(), cgiExtension.size(), cgiExtension) == 0;`
### 새로운 방법 find
`return uriWithoutQuery.find(cgiExtension, uriWithoutQuery.size() - cgiExtension.size()) == std::string::npos;`