### PR TITLE
fix: RequestParser에서 findRequestConfig 로직 순서 변경 및 도메인네임 파싱 추가

### DIFF
--- a/src/EventHandler/EventHandlerRecvRequest.cpp
+++ b/src/EventHandler/EventHandlerRecvRequest.cpp
@@ -56,7 +56,10 @@ EnumSesStatus EventHandler::recvRequest(ClientSession &curSession) {
 		if ((result == READ_COMPLETE || result == REQUEST_ERROR)
 		&& curSession.getConfig() == NULL) {
 			const GlobalConfig &globalConfig = GlobalConfig::getInstance();
-			curSession.setConfig(globalConfig.findRequestConfig(curSession.getListenFd(), curSession.accessReqMsg().getMetaHost(), curSession.accessReqMsg().getTargetURI()));
+			const RequestMessage *curMsg = curSession.getReqMsg();
+			size_t colonPos = curMsg->getMetaHost().find(":", 0);
+			std::string onlyDomainName = (colonPos == std::string::npos) ? curMsg->getMetaHost() : curMsg->getMetaHost().substr(0, colonPos);
+			curSession.setConfig(globalConfig.findRequestConfig(curSession.getListenFd(), onlyDomainName, curMsg->getTargetURI()));
 		}
 		return result;
 	}

--- a/src/RequestHandler/CgiHandler.cpp
+++ b/src/RequestHandler/CgiHandler.cpp
@@ -32,7 +32,7 @@ bool CgiHandler::isCGI(const std::string& targetUri, const std::string& cgiExten
     if (uriWithoutQuery.size() < cgiExtension.size()) {
         return false;
     }
-    return uriWithoutQuery.find(cgiExtension, uriWithoutQuery.size() - cgiExtension.size()) == std::string::npos;
+    return uriWithoutQuery.find(cgiExtension, uriWithoutQuery.size() - cgiExtension.size()) != std::string::npos;
 }
 
 // 클라이언트의 요청을 처리하여 CGI 결과를 반환하는 함수


### PR DESCRIPTION
## 버그 발견 배경
1. 같은 포트를 공유하는 다른 서버를 테스트하던 중, targetURI에 Domain name을 포함하면 정상작동하지 않음
2. #189 때 추가되었던 targetURI의 domain편집과 findRequestConfig의 순서를 바꿔주면 해결된다는 사실을 알았음


## 자료
- 입력했던 RequestMessage
`printf "GET A:8080/ HTTP/1.1\r\nHost: d\r\n\r\n" | nc 127.0.0.1 8080`

- 사용했던 multi_port.conf
```
server {
    listen 8080;
    server_name localhost;
    root ./www/html;
    index index.html;
}
server {
    listen 8080;
    server_name A;
    root ./www/html;
    index index2.html;
}
server {
    listen 8080;
    server_name B;
    root ./www/html;
    index index3.html;
}
```