### PR TITLE
fix: ConfigParser의 서버블록 중복검사오류 수정 및 중복서버 config파일 추가

### DIFF
--- a/config/multi_port.conf
+++ b/config/multi_port.conf
@@ -1,0 +1,22 @@
+server {
+    listen 8080;
+    server_name localhost;
+
+    root ./www/html;
+    index index.html;
+}
+
+server {
+    listen 8080;
+    server_name A;
+
+    root ./www/html;
+    index index2.html;
+}
+server {
+    listen 8080;
+    server_name B;
+
+    root ./www/html;
+    index index3.html;
+}

--- a/src/ConfigParser/ConfigParser.cpp
+++ b/src/ConfigParser/ConfigParser.cpp
@@ -219,7 +219,7 @@ void ConfigParser::setDefaultReqHandling(RequestConfig& reqConfig) {
 bool ConfigParser::isDuplicateServer(const std::vector<ServerConfig>& servers, const ServerConfig& server) {
     for (std::vector<ServerConfig>::const_iterator it = servers.begin(); it != servers.end(); ++it) {
         // 호스트와 포트가 모두 일치하는 서버가 있으면 중복으로 판단
-        if (it->host_ == server.host_ && it->port_ == server.port_) {
+        if (it->serverNames_ == server.serverNames_ && it->port_ == server.port_) {
             return true;
         }
     }


### PR DESCRIPTION
## 문제 원인
서버블록의 중복검사시, `host_`가 아닌 `serverName_`를 검사해야함