### PR TITLE
refactor: 하나의 event당 하나의, 한 번의 I/O만 처리하도록 수정

### DIFF
--- a/html/cgi-bin/form.py
+++ b/html/cgi-bin/form.py
@@ -1,4 +1,4 @@
-#!/Users/damin/francinette/venv/bin/python3
+#!/usr/bin/env python3
 
 import os
 import cgi

--- a/html/cgi-bin/hello.py
+++ b/html/cgi-bin/hello.py
@@ -1,4 +1,4 @@
-#!/Users/damin/francinette/venv/bin/python3
+#!/usr/bin/env python3
 
 import os
 import cgi

--- a/html/cgi-bin/info.py
+++ b/html/cgi-bin/info.py
@@ -1,4 +1,4 @@
-#!/Users/damin/francinette/venv/bin/python3
+#!/usr/bin/env python3
 
 import os
 import cgi

--- a/src/ClientSession/ClientSession.cpp
+++ b/src/ClientSession/ClientSession.cpp
@@ -4,7 +4,7 @@
 #define BUFFER_SIZE 8192
 #endif
 
-ClientSession::ClientSession(int listenFd, int clientFd, std::string clientIP) : listenFd_(listenFd), clientFd_(clientFd), reqMsg_(NULL), config_(NULL), clientIP_(clientIP) {
+ClientSession::ClientSession(int listenFd, int clientFd, std::string clientIP) : listenFd_(listenFd), clientFd_(clientFd), reqMsg_(NULL), config_(NULL), clientIP_(clientIP), connectionClosed_(false) {
 	this->readBuffer_.reserve(BUFFER_SIZE * 2);
 	this->defConfig_ = GlobalConfig::getInstance().findRequestConfig(listenFd, "", "");
 }
@@ -75,6 +75,14 @@ void ClientSession::setReadBuffer(const std::string &remainData) {
 void ClientSession::setWriteBuffer(const std::string &remainData) {
 	this->writeBuffer_ = remainData;
 	resetRequest();
+}
+
+void ClientSession::setConnectionClosed() {
+	connectionClosed_ = true;
+}
+
+bool ClientSession::isConnectionClosed() const{
+	return this->connectionClosed_;
 }
 
 bool ClientSession::isReceiving() const {

--- a/src/ClientSession/ClientSession.hpp
+++ b/src/ClientSession/ClientSession.hpp
@@ -25,6 +25,8 @@ class ClientSession {
 		void					setConfig(const RequestConfig *config);
 		void					setReadBuffer(const std::string &remainData);
 		void					setWriteBuffer(const std::string &remainData);
+		void					setConnectionClosed();
+		bool					isConnectionClosed() const;
 		bool					isReceiving() const;
 
 		RequestMessage			&accessReqMsg();
@@ -40,6 +42,7 @@ class ClientSession {
 		std::string				readBuffer_;
 		std::string				writeBuffer_;
 		std::string				clientIP_;
+		bool					connectionClosed_;
 		
 		void					resetRequest();
 };

--- a/src/TimeoutHandler/TimeoutHandler.cpp
+++ b/src/TimeoutHandler/TimeoutHandler.cpp
@@ -88,6 +88,10 @@ void TimeoutHandler::checkTimeouts(EventHandler& eventHandler, Demultiplexer& re
             eventHandler.handleError(408, *client);
             reactor.addWriteEvent(fd);
             client->setConnectionClosed();
+        } else {
+            //IDLE Timeout일 경우 나머지 리소스도 정리
+            clientManager.removeClient(fd);
+            reactor.removeSocket(fd);
         }
 
         // TimeoutHandler에서 관리하는 client 정보 삭제 및 정리


### PR DESCRIPTION
## 변경사항
> [ 📝 평가 요구사항 中... ]
> There should be only one read or one write per client per select.

하나의 이벤트 당 `하나의`&`한 번의` I/O만 처리 하도록 변경합니다.


### 1. 모든 send()는 write 이벤트를 통해서만 이루어지도록 수정
: 기존 handleReadEvent, handleError 내 sendResponse 로직을 제거했습니다.
따라서 두 메소드에서는 response내용을 clientSession 내 write 버퍼에 세팅하는 역할까지만 수행합니다.
또한 handleReadEvent에서는 recv에 따른 status 반환만 가능합니다.
(`READ_CONTINUE`, `READ_COMPLETE`, `REQUEST_ERROR`, `CONNECTION_CLOSED`)

### 2. ClientSession 내에서 bool 타입의 `connectionClosed_` 멤버변수 관리
: 기존`CONNECTION_CLOSED`로 즉각 연결을 종료하던 방식이 일부 상황에 대해 불가능해졌습니다.
따라서 향후 연결 정리가 필요한지 여부를 파악할 수 있는 멤버변수를 추가했습니다. 
기본적으로 false로 초기화되며, setConnectionClosed()를 통해 true로 변환할 수 있습니다. 
`REQUEST_ERROR` 혹은 타임아웃 시, 해당 메소드를 호출합니다(바로 write가 불가한 경우).
handleWriteEvent내에서 response 전송 후, isConnectionClosed()를 통해 해당 플래그를 확인합니다. 
true일 경우 `CONNECTION_CLOSED` 반환 후 연결을 정리합니다. 

### 3. handleError를 event 감지 외에 호출하는 케이스의 로직 수정
: 기존에는 timeout 시, 그리고 graceful shutdown 시 handleError를 호출했습니다.
로직 변화에 따른 각 케이스의 변경 사항은 다음과 같습니다.

**(1) TimeoutHandler.checkTimeouts() 수정**
: 408 반환이 필요한 경우 write이벤트를 등록합니다. 이 때, 향후 응답 전송을 위해 ClientManager와 Demultiplexer(reactor)에 대한 리소스 정리는 진행하지 않습니다. 
IDLE timeout의 경우, 별도의 응답전송이 필요하지 않으므로, 모든 클라이언트 정보를 정리합니다.

**(2) 서버 종료 시 ServerManager.notifyClientShutdown() 제거**
: 모든 I/O처리는 이벤트 발생 시에만 허용된다는 과제 요구사항에 따라, 
 서버 종료 전, 연결되어 있는 클라이언트에 안내하는 Graceful Shutdown을 지원하지 않습니다. 
 별도의 고지 없이 리소스 정리 후 종료합니다.



## 향후 해결 과제
이번 수정 사항은 오로지 과제 요구사항을 충족하기 위한 것으로, 보편적인 웹서버에 비해 다소 비효율적인 방법으로 이벤트를 처리합니다.
siege테스트 시, m2 맥북 에어 환경에서는 100개 클라이언트로 부터의 극한의 부하를 1분 동안 가한 결과 100% Available 했습니다.
그래서 안심했으나... m1 맥북 pro 환경에서는 50개 클라이언트로 30초 동한 테스트하여도 93.99% Available로 기준에 미달하는 것을 확인했습니다. (기존 로직은 100%)
따라서 추가적인 최적화가 필요합니다. 
고려중인 해결 방안으로는 별도의 socket상태 확인 로직 추가, `SO_LINGER`옵션 적용 등이 있습니다. 