### PR TITLE
feat: 아무 메서드도 허용하지 않는 설정 방법 추가

### DIFF
--- a/src/ConfigParser/parse_location_block.cpp
+++ b/src/ConfigParser/parse_location_block.cpp
@@ -22,10 +22,20 @@ void ConfigParser::parseMethods(std::ifstream& configFile, std::vector<std::stri
 		if (nextToken.empty()) {
 			throw std::runtime_error("Unexpected end of file in methods directive");
 		} else if (nextToken == ";") {
+			if (methods.empty()) {
+				// 메서드가 비어있으면 빈 문자열로 아무 메서드도 허용하지 않음을 나타냄
+				methods.push_back("");
+			}
 			break;
 		} else {
-			// 메서드 이름들을 methods 벡터에 추가
-			methods.push_back(nextToken);
+			if (!methods.empty() && methods.front() == "") {
+				// 첫 번째 원소가 빈 문자열이면 제거
+				methods.erase(methods.begin());
+			}
+			if (methods.end() == std::find(methods.begin(), methods.end(), nextToken)) {
+				// 메서드가 중복되지 않으면 추가
+				methods.push_back(nextToken);
+			}
 			nextToken = getNextToken(configFile);
 		}
 	}


### PR DESCRIPTION
- 메서드 지시자가 없으면 기본값(GET, POST, DELETE 허용)을 설정합니다.
- 메서드 지시자 뒤에 값 없이 세미콜론으로 끝나면 아무 지시자도 허용하지 않습니다.
- 메서드 지시자가 여러개 오면 허용되는 메서드를 합집합으로 계산합니다.