### PR TITLE
fix: 인덱스 파일의 경로을 올바르게 구하도록 수정

### DIFF
--- a/src/ConfigParser/ConfigParser.cpp
+++ b/src/ConfigParser/ConfigParser.cpp
@@ -40,14 +40,14 @@ void ConfigParser::parse(GlobalConfig& globalConfig, const char* path) {
 	// 각 location 블록에 대해 server의 request handling을 적용
 	for (std::vector<ServerConfig>::iterator server = globalConfig.servers_.begin(); server != globalConfig.servers_.end(); ++server) {
 		for (std::vector<LocationConfig>::iterator location = server->locations_.begin(); location != server->locations_.end(); ++location) {
-			getEffectiveReqHandling(server->reqConfig_, location->reqConfig_);
+			getEffectiveReqConfig(server->reqConfig_, location->reqConfig_);
 		}
 	}
 	// 각 request handling에 대해 기본값을 설정
 	for (std::vector<ServerConfig>::iterator server = globalConfig.servers_.begin(); server != globalConfig.servers_.end(); ++server) {
-		setDefaultReqHandling(server->reqConfig_);
+		setDefaultReqConfig(server->reqConfig_);
 		for (std::vector<LocationConfig>::iterator location = server->locations_.begin(); location != server->locations_.end(); ++location) {
-			setDefaultReqHandling(location->reqConfig_);
+			setDefaultReqConfig(location->reqConfig_);
 		}
 	}
 }
@@ -100,7 +100,7 @@ void ConfigParser::parseServerBlock(std::ifstream& configFile, ServerConfig& ser
 // location 블록을 파싱하는 함수
 void ConfigParser::parseLocationBlock(std::ifstream& configFile, LocationConfig& locationBlock) {
 	// location 경로 토큰을 파싱함
-	parsePath(configFile, locationBlock.path_);
+	parseLocationPath(configFile, locationBlock.reqConfig_.locationPath_);
 
 	// location 블록 시작 '{'를 기대함
 	std::string token = getNextToken(configFile);
@@ -160,41 +160,41 @@ void ConfigParser::parseRequestConfig(std::ifstream& configFile, RequestConfig& 
 }
 
 // 서버 설정의 request handling을 location 설정에 적용하는 함수
-void ConfigParser::getEffectiveReqHandling(const RequestConfig& serverReqHandling, RequestConfig& locationReqHandling) {
-	if (locationReqHandling.methods_.empty()) {
-		locationReqHandling.methods_ = serverReqHandling.methods_;
+void ConfigParser::getEffectiveReqConfig(const RequestConfig& serverReqConfig, RequestConfig& locationReqConfig) {
+	if (locationReqConfig.methods_.empty()) {
+		locationReqConfig.methods_ = serverReqConfig.methods_;
 	}
-	if (locationReqHandling.errorPages_.empty()) {
-		locationReqHandling.errorPages_ = serverReqHandling.errorPages_;
+	if (locationReqConfig.errorPages_.empty()) {
+		locationReqConfig.errorPages_ = serverReqConfig.errorPages_;
 	}
-	if (locationReqHandling.returnUrl_.empty()) {
-		locationReqHandling.returnUrl_ = serverReqHandling.returnUrl_;
+	if (locationReqConfig.returnUrl_.empty()) {
+		locationReqConfig.returnUrl_ = serverReqConfig.returnUrl_;
 	}
-	if (locationReqHandling.returnStatus_ == 0) {
-		locationReqHandling.returnStatus_ = serverReqHandling.returnStatus_;
+	if (locationReqConfig.returnStatus_ == 0) {
+		locationReqConfig.returnStatus_ = serverReqConfig.returnStatus_;
 	}
-	if (locationReqHandling.root_.empty()) {
-		locationReqHandling.root_ = serverReqHandling.root_;
+	if (locationReqConfig.root_.empty()) {
+		locationReqConfig.root_ = serverReqConfig.root_;
 	}
-	if (locationReqHandling.indexFile_.empty()) {
-		locationReqHandling.indexFile_ = serverReqHandling.indexFile_;
+	if (locationReqConfig.indexFile_.empty()) {
+		locationReqConfig.indexFile_ = serverReqConfig.indexFile_;
 	}
-	if (locationReqHandling.uploadPath_.empty()) {
-		locationReqHandling.uploadPath_ = serverReqHandling.uploadPath_;
+	if (locationReqConfig.uploadPath_.empty()) {
+		locationReqConfig.uploadPath_ = serverReqConfig.uploadPath_;
 	}
-	if (locationReqHandling.cgiExtension_.empty()) {
-		locationReqHandling.cgiExtension_ = serverReqHandling.cgiExtension_;
+	if (locationReqConfig.cgiExtension_.empty()) {
+		locationReqConfig.cgiExtension_ = serverReqConfig.cgiExtension_;
 	}
-	if (!locationReqHandling.clientMaxBodySize_.isSet()) {
-		locationReqHandling.clientMaxBodySize_ = serverReqHandling.clientMaxBodySize_;
+	if (!locationReqConfig.clientMaxBodySize_.isSet()) {
+		locationReqConfig.clientMaxBodySize_ = serverReqConfig.clientMaxBodySize_;
 	}
-	if (!locationReqHandling.autoIndex_.isSet()) {
-		locationReqHandling.autoIndex_ = serverReqHandling.autoIndex_;
+	if (!locationReqConfig.autoIndex_.isSet()) {
+		locationReqConfig.autoIndex_ = serverReqConfig.autoIndex_;
 	}
 }
 
 // request handling에 기본값을 설정하는 함수
-void ConfigParser::setDefaultReqHandling(RequestConfig& reqConfig) {
+void ConfigParser::setDefaultReqConfig(RequestConfig& reqConfig) {
 	if (reqConfig.methods_.empty()) {
 		// 기본 메서드는 GET, POST, DELETE
 		reqConfig.methods_.push_back("GET");

--- a/src/ConfigParser/ConfigParser.hpp
+++ b/src/ConfigParser/ConfigParser.hpp
@@ -30,10 +30,10 @@ private:
 	static void	parseRequestConfig(std::ifstream& configFile, RequestConfig& reqConfig, const std::string& token);
 
 	// LocationBlock이 ServerBlock의 값을 상속받은 후 오버라이드
-	static void	getEffectiveReqHandling(const RequestConfig& serverReqHandling, \
-										RequestConfig& locationReqHandling);
+	static void	getEffectiveReqConfig(const RequestConfig& serverReqConfig, \
+										RequestConfig& locationReqConfig);
 	// 설정값이 없을 경우 기본값으로 초기화
-	static void	setDefaultReqHandling(RequestConfig& ReqHandling);
+	static void	setDefaultReqConfig(RequestConfig& ReqConfig);
 	// 주어진 서버 목록에서 같은 호스트와 포트를 가진 중복 서버가 있는지 확인
 	static bool isDuplicateServer(const std::vector<ServerConfig>& servers, const ServerConfig& server);
 
@@ -42,7 +42,7 @@ private:
 	static void	parseServerNames(std::ifstream& configFile, std::vector<std::string>& serverNames);
 	
 	// LocationBlock 파서
-	static void	parsePath(std::ifstream& configFile, std::string& path);
+	static void	parseLocationPath(std::ifstream& configFile, std::string& path);
 	static void	parseMethods(std::ifstream& configFile, std::vector<std::string>& methods);
 
 	// RequestConfig 파서

--- a/src/ConfigParser/parse_location_block.cpp
+++ b/src/ConfigParser/parse_location_block.cpp
@@ -3,7 +3,7 @@
 // LocationBlock 파서를 위한 함수들
 
 // location 지시문의 경로를 파싱하는 함수
-void ConfigParser::parsePath(std::ifstream& configFile, std::string& path) {
+void ConfigParser::parseLocationPath(std::ifstream& configFile, std::string& locationPath) {
 	std::string nextToken = getNextToken(configFile);
 	if (nextToken.empty()) {
 		throw std::runtime_error("Unexpected end of file in location directive");
@@ -11,7 +11,7 @@ void ConfigParser::parsePath(std::ifstream& configFile, std::string& path) {
 		throw std::runtime_error("Expected path for location directive");
 	}
 	// 읽어온 토큰을 경로로 설정
-	path = nextToken;
+	locationPath = nextToken;
 }
 
 // methods 지시문을 파싱하는 함수

--- a/src/GlobalConfig/GlobalConfig.cpp
+++ b/src/GlobalConfig/GlobalConfig.cpp
@@ -32,7 +32,7 @@ void GlobalConfig::destroyInstance() {
 // GlobalConfig 클래스 내의 findRequestConfig 함수: 
 // listenFd, 도메인 이름, 그리고 target URL에 해당하는 RequestConfig를 찾는다.
 const RequestConfig* GlobalConfig::findRequestConfig(const int listenFd, const std::string& domainName, \
-const std::string& targetUrl) const {
+const std::string& targetUri) const {
 	// listenFd가 등록된 서버 목록에 없다면 NULL 반환
 	if (listenFdToServers_.find(listenFd) == listenFdToServers_.end())
 		return NULL;
@@ -41,7 +41,7 @@ const std::string& targetUrl) const {
 	// 주어진 도메인 이름과 일치하는 서버 구성을 찾음
 	const ServerConfig& server = findServerConfig(servers, domainName);
 	// 해당 서버에서 target URL에 해당하는 location 설정을 찾음
-	return findLocationConfig(server, targetUrl);
+	return findLocationConfig(server, targetUri);
 }
 
 
@@ -67,19 +67,19 @@ const std::string& domainName) const {
 // GlobalConfig 클래스 내의 findLocationConfig 함수: 
 // 주어진 서버 설정 내에서 target URL과 가장 잘 맞는 location 설정을 찾는다.
 const RequestConfig* GlobalConfig::findLocationConfig(const ServerConfig& server, \
-const std::string& targetUrl) const {
-	// targetUrl이 비어있으면 서버의 기본 RequestConfig를 반환
-	if (targetUrl.empty()) {
+const std::string& targetUri) const {
+	// targetUri이 비어있으면 서버의 기본 RequestConfig를 반환
+	if (targetUri.empty()) {
 		return &server.reqConfig_;
 	}
 	const LocationConfig* longestPrefixMatch = NULL; // 가장 긴 접두어 매칭을 저장할 포인터 초기화
 	// 서버의 location 설정 목록을 순회
 	for (size_t i = 0; i < server.locations_.size(); ++i) {
-		// targetUrl이 현재 location의 path_로 시작하는지 확인
-		if (targetUrl.find(server.locations_[i].path_) == 0) {
+		// targetUri이 현재 location의 locationPath_로 시작하는지 확인
+		if (targetUri.find(server.locations_[i].reqConfig_.locationPath_) == 0) {
 			// 현재 매칭이 이전보다 길거나 아직 매칭이 없으면 업데이트
 			if (longestPrefixMatch == NULL || \
-				server.locations_[i].path_.size() > longestPrefixMatch->path_.size())
+				server.locations_[i].reqConfig_.locationPath_.size() > longestPrefixMatch->reqConfig_.locationPath_.size())
 				longestPrefixMatch = &server.locations_[i];
 		}
 	}
@@ -111,7 +111,7 @@ void GlobalConfig::print() const {
         if (!servers_[i].locations_.empty()) {
             std::cout << "\n--- Location Blocks ---\n";
             for (size_t j = 0; j < servers_[i].locations_.size(); j++) {
-                std::cout << "Location [" << servers_[i].locations_[j].path_ << "]:\n";
+                std::cout << "Location [" << servers_[i].locations_[j].reqConfig_.locationPath_ << "]:\n";
                 servers_[i].locations_[j].reqConfig_.print(1);  // Pass indentation level
                 std::cout << "\n";
             }

--- a/src/GlobalConfig/GlobalConfig.hpp
+++ b/src/GlobalConfig/GlobalConfig.hpp
@@ -18,6 +18,7 @@ public:
 	RequestConfig() : returnStatus_(0) {}			// 기본 생성자는 멤버를 기본값으로 초기화합니다.
 
 	std::vector<std::string>	methods_;			// 예: GET, POST 등
+	std::string					locationPath_;		// 위치 경로 (예: "/images")
 	std::map<int, std::string>	errorPages_;		// 오류 코드와 오류 페이지 매핑
 	std::string					returnUrl_;			// 반환 또는 리디렉션할 URL
 	int							returnStatus_;		// 리디렉션/반환을 위한 HTTP 상태 코드
@@ -35,7 +36,6 @@ public:
 // LocationConfig는 특정 위치 블록의 구성을 나타냅니다.
 class LocationConfig {
 public:
-	std::string					path_;				// 위치 경로 (예: "/images")
 	RequestConfig				reqConfig_;			// 이 위치의 요청 처리 구성
 };
 
@@ -70,7 +70,7 @@ public:
 	// 리스닝 소켓 디스크립터, 도메인 이름, 대상 URL에 해당하는 요청 설정 찾기
 	const RequestConfig*		findRequestConfig(const int listenFd, \
 												const std::string& domainName, \
-												const std::string& targetUrl) const;
+												const std::string& targetUri) const;
 	// 설정 정보 출력
 	void						print() const;
 
@@ -87,7 +87,7 @@ private:
 											const std::string& domainName) const;
 	// 대상 URI에 해당하는 location 설정 찾기
 	const RequestConfig*	findLocationConfig(const ServerConfig& server, \
-												const std::string& targetUrl) const;
+												const std::string& targetUri) const;
 };
 
 #endif

--- a/src/RequestHandler/CgiHandler.cpp
+++ b/src/RequestHandler/CgiHandler.cpp
@@ -270,7 +270,8 @@ UriParts CgiHandler::parseUri(const std::string& uri, const RequestConfig& conf)
     UriParts parts;                                             // 결과를 저장할 UriParts 구조체
     std::string fullPath;                   
     if (FileUtilities::isDirectory(FileUtilities::joinPaths(conf.root_, uri).c_str())) {
-        fullPath = FileUtilities::joinPaths(conf.root_, conf.indexFile_);
+		std::string locationRootPath = FileUtilities::joinPaths(conf.root_, conf.locationPath_);
+        fullPath = FileUtilities::joinPaths(locationRootPath, conf.indexFile_);
     } else {
         fullPath = FileUtilities::joinPaths(conf.root_, uri);  // 루트 경로와 URI를 결합하여 전체 경로 생성
     }

--- a/src/RequestHandler/StaticHandler.cpp
+++ b/src/RequestHandler/StaticHandler.cpp
@@ -238,7 +238,8 @@ std::string StaticHandler::handleDirectory(const std::string &dirPath,
 	const std::string &uri,
 	const RequestConfig &conf)
 {
-	std::string indexPath = FileUtilities::joinPaths(conf.root_, conf.indexFile_);
+	std::string locationRootPath = FileUtilities::joinPaths(conf.root_, conf.locationPath_);
+	std::string indexPath = FileUtilities::joinPaths(locationRootPath, conf.indexFile_);
 
 	EnumValidationResult indexValidation = validatePath(indexPath);
 


### PR DESCRIPTION
- LocationConfig::path를 RequestConfig::locationPath로 이동
- index의 파일의 경로를 구할때
 root + locationPath + indexFile으로 구하도록 수정

- 함수 이름들에서 Handling을 Config로 수정
- targetUrl -> targetUri로 수정

테스트 방법
- 루트 디렉토리가 아닌 장소에 있는 cgi 파일을 인덱스 파일로 지정하고
해당 파일의 디렉토리에 GET 요청을 보냈을 때 cgi로 처리되는것을 확인