### PR TITLE
fix: 파일의 중간경로의 실행권한이 없을때 forbidden 반환

### DIFF
--- a/src/RequestHandler/StaticHandler.cpp
+++ b/src/RequestHandler/StaticHandler.cpp
@@ -224,12 +224,19 @@ std::string StaticHandler::handleDeleteRequest(const RequestMessage& reqMsg, con
 			return responseBuilder_.buildError(FORBIDDEN, conf);
 		}
 	}
-	// 디렉토리거나 없으면 에러
+	// 디렉토리는 삭제를 허용하지 않음
 	if (pathValidation == VALID_PATH) {
+		DEBUG_LOG("[StaticHandler]Deleting directory: " + fullPath);
 		// 디렉토리
 		return responseBuilder_.buildError(FORBIDDEN, conf);
 	}
-	return responseBuilder_.buildError(NOT_FOUND, conf);
+	// 파일이나 경로가 없음
+	if (pathValidation == PATH_NOT_FOUND || pathValidation == FILE_NOT_FOUND) {
+		DEBUG_LOG("[StaticHandler]File not found: " + fullPath);
+		return responseBuilder_.buildError(NOT_FOUND, conf);
+	}
+	// 접근 권한 없음
+	return responseBuilder_.buildError(FORBIDDEN, conf);
 }
 
 // ─────────────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
- 디렉토리의 실행 권한이 없어서 파일을 삭제할 수 없을때
서버가 forbidden을 반환하도록 수정