### PR TITLE
fix: 파일의 중간경로의 실행권한이 없을때 forbidden 반환

### DIFF
--- a/src/ConfigParser/parse_location_block.cpp
+++ b/src/ConfigParser/parse_location_block.cpp
@@ -9,6 +9,9 @@ void ConfigParser::parseLocationPath(std::ifstream& configFile, std::string& loc
 		throw std::runtime_error("Unexpected end of file in location directive");
 	} else if (nextToken == ";") {
 		throw std::runtime_error("Expected path for location directive");
+	} else if (nextToken[0] != '/') {
+		// 가장 앞글자가 "/"가 아니면 예외 발생
+		throw std::runtime_error("Expected '/' at the beginning of location path");
 	}
 	// 읽어온 토큰을 경로로 설정
 	locationPath = nextToken;

--- a/src/EventHandler/EventHandler.cpp
+++ b/src/EventHandler/EventHandler.cpp
@@ -74,11 +74,13 @@ EnumSesStatus EventHandler::handleClientReadEvent(ClientSession& clientSession) 
 			// 리다이렉션
 			DEBUG_LOG("[EventHandler]Redirection requested")
 			responseMsg = handleRedirection(reqConfig);
-		} else if (cgiHandler_.isCGI(requestMsg.getTargetURI(), reqConfig)) {
+		} else if (cgiHandler_.isCGI(requestMsg.getMethod(), requestMsg.getTargetURI(), reqConfig)) {
             // CGI 요청
+			DEBUG_LOG("[EventHandler]CGI request");
             responseMsg = cgiHandler_.handleRequest(clientSession);
         } else {
             // 정적 파일 요청
+			DEBUG_LOG("[EventHandler]Static file request");
             responseMsg = staticHandler_.handleRequest(requestMsg, reqConfig);
         }
         // 생성된 응답 메시지를 클라이언트 세션의 쓰기 버퍼에 저장

--- a/src/GlobalConfig/GlobalConfig.cpp
+++ b/src/GlobalConfig/GlobalConfig.cpp
@@ -123,6 +123,10 @@ void GlobalConfig::print() const {
 void RequestConfig::print(int indentLevel) const {
     std::string indent(indentLevel * 2, ' ');
     
+	// locationPath
+	std::cout << indent << "Location Path:     ";
+	std::cout << locationPath_ << "\n";
+
     // Methods
     std::cout << indent << "Methods:            ";
     if (methods_.empty()) {

--- a/src/RequestHandler/CgiHandler.cpp
+++ b/src/RequestHandler/CgiHandler.cpp
@@ -23,8 +23,13 @@ CgiHandler::~CgiHandler() {
 }
 
 // 요청된 URI가 CGI 실행 대상인지 확인하는 함수
-bool CgiHandler::isCGI(const std::string& targetUri, const RequestConfig& conf)
+bool CgiHandler::isCGI(const EnumMethod method, const std::string& targetUri, const RequestConfig& conf)
 {
+	// 요청 메서드가 GET 또는 POST가 아니면 CGI 아님
+	if (method != GET && method != POST) {
+		return false;
+	}
+
 	const std::string& cgiExtension = conf.cgiExtension_;
 
 	// 디렉터리인지 확인하고 indexFile이 CGI인지 검사

--- a/src/RequestHandler/CgiHandler.hpp
+++ b/src/RequestHandler/CgiHandler.hpp
@@ -22,7 +22,9 @@ public:
     ~CgiHandler();
 
     // 주어진 URI가 CGI 대상인지 확인하는 함수
-    bool isCGI(const std::string& targetUri, const RequestConfig& conf);
+    bool isCGI(const EnumMethod method,
+				const std::string& targetUri,
+				const RequestConfig& conf);
     // 클라이언트 요청을 처리하여 CGI 실행 결과를 반환하는 함수
     std::string handleRequest(const ClientSession& clientSession);
 

--- a/src/RequestHandler/StaticHandler.cpp
+++ b/src/RequestHandler/StaticHandler.cpp
@@ -227,14 +227,18 @@ std::string StaticHandler::handleDeleteRequest(const RequestMessage& reqMsg, con
 			return responseBuilder_.buildError(FORBIDDEN, conf);
 		}
 	}
-	// 디렉토리거나 없으면 에러
+	// 디렉토리는 삭제를 허용하지 않음
 	if (pathValidation == VALID_PATH) {
 		DEBUG_LOG("[StaticHandler]Deleting directory: " + fullPath);
-		// 디렉토리
 		return responseBuilder_.buildError(FORBIDDEN, conf);
 	}
-	DEBUG_LOG("[StaticHandler]File not found: " + fullPath);
-	return responseBuilder_.buildError(NOT_FOUND, conf);
+	// 파일이나 경로가 없음
+	if (pathValidation == PATH_NOT_FOUND || pathValidation == FILE_NOT_FOUND) {
+		DEBUG_LOG("[StaticHandler]File not found: " + fullPath);
+		return responseBuilder_.buildError(NOT_FOUND, conf);
+	}
+	// 접근 권한 없음
+	return responseBuilder_.buildError(FORBIDDEN, conf);
 }
 
 // ─────────────────────────────────────────────────────────────────────────────────────

--- a/src/RequestHandler/StaticHandler.cpp
+++ b/src/RequestHandler/StaticHandler.cpp
@@ -1,5 +1,6 @@
 #include "StaticHandler.hpp"
 #include "../include/commonEnums.hpp"
+#include "errorUtils.hpp"
 #include <dirent.h>
 #include <errno.h>
 #include <cctype>
@@ -206,6 +207,7 @@ std::string StaticHandler::extractFilename(const std::string& contentDisposition
 //  - 파일만 삭제한다 가정 (디렉토리 삭제는 고려하지 않음)
 //  - 실제로 remove() 호출
 std::string StaticHandler::handleDeleteRequest(const RequestMessage& reqMsg, const RequestConfig& conf) {
+	DEBUG_LOG("[StaticHandler]DELETE request received");
 	std::string uri = reqMsg.getTargetURI();
 	std::string fullPath = FileUtilities::joinPaths(conf.root_, uri);
 
@@ -213,6 +215,7 @@ std::string StaticHandler::handleDeleteRequest(const RequestMessage& reqMsg, con
 	EnumValidationResult pathValidation = validatePath(fullPath);
 
 	if (pathValidation == VALID_FILE) {
+		DEBUG_LOG("[StaticHandler]Deleting file: " + fullPath);
 		// 파일 삭제 시도
 		if (std::remove(fullPath.c_str()) == 0) {
 			// 성공
@@ -226,9 +229,11 @@ std::string StaticHandler::handleDeleteRequest(const RequestMessage& reqMsg, con
 	}
 	// 디렉토리거나 없으면 에러
 	if (pathValidation == VALID_PATH) {
+		DEBUG_LOG("[StaticHandler]Deleting directory: " + fullPath);
 		// 디렉토리
 		return responseBuilder_.buildError(FORBIDDEN, conf);
 	}
+	DEBUG_LOG("[StaticHandler]File not found: " + fullPath);
 	return responseBuilder_.buildError(NOT_FOUND, conf);
 }
 

--- a/src/RequestMessage/RequestMessage.cpp
+++ b/src/RequestMessage/RequestMessage.cpp
@@ -168,7 +168,7 @@ void RequestMessage::printBody(void) const {
 void RequestMessage::printMetaData(void) const {
 	std::cout << "\033[37;7m MetaData :\033[0m"<<std::endl;
 	std::cout <<"\033[37;2mHost_: ";
-	if (this->metaHost_.empty())
+	if (!this->metaHost_.empty())
 		std::cout <<this->metaHost_ <<";\033[0m\n";
 	else
 		std::cout <<"(none);\033[0m\n";


### PR DESCRIPTION
- 디렉토리의 실행 권한이 없어서 파일을 삭제할 수 없을때
서버가 forbidden을 반환하도록 수정

fix: isCGI가 DELETE 요청에 false로 반환하도록 수정
    
- isCGI 매개변수 추가: const EnumMethod
- DELETE 실행 흐름 디버깅 메세지 출력 코드 추가

fix: location path 앞에 '/'가 오도록 수정
    
- 가장 앞글자가 "/"가 아니면 예외 발생
- RequestConfig::print에서 location path를 출력하도록 변경
- RequestMessage::printMetaData의 조건식 오류 수정