### PR TITLE
chore: std::find 헤더파일 인클루드 누락

### DIFF
--- a/src/ConfigParser/ConfigParser.hpp
+++ b/src/ConfigParser/ConfigParser.hpp
@@ -12,6 +12,7 @@
 #include <cctype>			// std::isdigit, std::isxdigit, std::isspace, std::tolower
 #include <iterator>			// std::iterator
 #include <cstdlib>			// strtoul
+#include <algorithm>		// std::find
 
 class GlobalConfig;
 class ServerConfig;


### PR DESCRIPTION
컨테이너에서 c++98을 만족하는지 테스트해보았습니다.