### PR TITLE
Refactor/optimize loop

### DIFF
--- a/src/ClientSession/ClientSession.cpp
+++ b/src/ClientSession/ClientSession.cpp
@@ -4,7 +4,7 @@
 #define BUFFER_SIZE 8192
 #endif
 
-ClientSession::ClientSession(int listenFd, int clientFd, std::string clientIP) : listenFd_(listenFd), clientFd_(clientFd), reqMsg_(NULL), config_(NULL), clientIP_(clientIP), connectionClosed_(false) {
+ClientSession::ClientSession(int listenFd, int clientFd, std::string clientIP) : listenFd_(listenFd), clientFd_(clientFd), reqMsg_(NULL), config_(NULL), clientIP_(clientIP) {
 	this->readBuffer_.reserve(BUFFER_SIZE * 2);
 	this->defConfig_ = GlobalConfig::getInstance().findRequestConfig(listenFd, "", "");
 }
@@ -75,14 +75,6 @@ void ClientSession::setReadBuffer(const std::string &remainData) {
 void ClientSession::setWriteBuffer(const std::string &remainData) {
 	this->writeBuffer_ = remainData;
 	resetRequest();
-}
-
-void ClientSession::setConnectionClosed() {
-	connectionClosed_ = true;
-}
-
-bool ClientSession::isConnectionClosed() const{
-	return this->connectionClosed_;
 }
 
 bool ClientSession::isReceiving() const {

--- a/src/ClientSession/ClientSession.hpp
+++ b/src/ClientSession/ClientSession.hpp
@@ -25,8 +25,6 @@ class ClientSession {
 		void					setConfig(const RequestConfig *config);
 		void					setReadBuffer(const std::string &remainData);
 		void					setWriteBuffer(const std::string &remainData);
-		void					setConnectionClosed();
-		bool					isConnectionClosed() const;
 		bool					isReceiving() const;
 
 		RequestMessage			&accessReqMsg();
@@ -42,7 +40,6 @@ class ClientSession {
 		std::string				readBuffer_;
 		std::string				writeBuffer_;
 		std::string				clientIP_;
-		bool					connectionClosed_;
 		
 		void					resetRequest();
 };

--- a/src/ServerManager/ServerManagerRun.cpp
+++ b/src/ServerManager/ServerManagerRun.cpp
@@ -12,47 +12,42 @@
 void ServerManager::run() {
 	EventHandler 	eventHandler;
 	ClientManager	clientManager;
+	Demultiplexer	reactor(listenFds_);
+	TimeoutHandler	timeoutHandler;
 
-	try {
-		Demultiplexer	reactor(listenFds_);
-		TimeoutHandler	timeoutHandler;
+	while (isServerRunning()) {
+		// 발생한 이벤트의 개수를 확인
+		DEBUG_LOG("[ServerManager]Waiting for events...")
 
-		while (isServerRunning()) {
-			// 발생한 이벤트의 개수를 확인
-			DEBUG_LOG("[ServerManager]Waiting for events...")
+		timespec* timeout = timeoutHandler.getEarliestTimeout();
+		int	numEvents = reactor.waitForEvent(timeout);
 
-			timespec* timeout = timeoutHandler.getEarliestTimeout();
-			int	numEvents = reactor.waitForEvent(timeout);
+		// 발생한 각 이벤트를 순회하며 처리
+		for (int i = 0; i < numEvents; ++i) {
+			EnumEvent	type = reactor.getEventType(i);
+			int 		fd = reactor.getSocketFd(i);
 
-			// 발생한 각 이벤트를 순회하며 처리
-			for (int i = 0; i < numEvents; ++i) {
-				EnumEvent	type = reactor.getEventType(i);
-				int 		fd = reactor.getSocketFd(i);
-
-				if (type == READ_EVENT) {
-					if (isListeningSocket(fd)) {
-						DEBUG_LOG("[ServerManager]READ Event on Listening Socket: fd " << fd)
-						// 리스닝 소켓에서 읽기 이벤트 발생: 새로운 클라이언트의 연결 요청 처리
-						processServerReadEvent(
-							fd, clientManager, eventHandler, timeoutHandler, reactor);
-					} else {
-						DEBUG_LOG("[ServerManager]READ Event on Client Socket: fd " << fd)
-						// 기존 클라이언트 소켓에서 읽기 이벤트 발생: 클라이언트로부터 데이터 수신 처리
-						processClientReadEvent(
-							fd, clientManager, eventHandler, timeoutHandler, reactor);
-					}
-				} else if (type == WRITE_EVENT) {
-					DEBUG_LOG("[ServerManager]WRITE Event on Client Socket: fd " << fd)
-					// 쓰기 이벤트 발생: 클라이언트에게 데이터를 전송하는 작업 처리
-					processClientWriteEvent(
+			if (type == READ_EVENT) {
+				if (isListeningSocket(fd)) {
+					DEBUG_LOG("[ServerManager]READ Event on Listening Socket: fd " << fd)
+					// 리스닝 소켓에서 읽기 이벤트 발생: 새로운 클라이언트의 연결 요청 처리
+					processServerReadEvent(
+						fd, clientManager, eventHandler, timeoutHandler, reactor);
+				} else {
+					DEBUG_LOG("[ServerManager]READ Event on Client Socket: fd " << fd)
+					// 기존 클라이언트 소켓에서 읽기 이벤트 발생: 클라이언트로부터 데이터 수신 처리
+					processClientReadEvent(
 						fd, clientManager, eventHandler, timeoutHandler, reactor);
 				}
+			} else if (type == WRITE_EVENT) {
+				DEBUG_LOG("[ServerManager]WRITE Event on Client Socket: fd " << fd)
+				// 쓰기 이벤트 발생: 클라이언트에게 데이터를 전송하는 작업 처리
+				processClientWriteEvent(
+					fd, clientManager, eventHandler, timeoutHandler, reactor);
 			}
-			// 타임아웃된 클라이언트 확인 후 처리
-			timeoutHandler.checkTimeouts(eventHandler, reactor, clientManager);
 		}
-	} catch (std::exception& e) {
-		throw; // 원래 예외 그대로 throw
+		// 타임아웃된 클라이언트 확인 후 처리
+		timeoutHandler.checkTimeouts(eventHandler, reactor, clientManager);
 	}
 }
 
@@ -109,7 +104,7 @@ void ServerManager::processClientReadEvent(int fd, ClientManager& clientManager,
 		removeClientInfo(fd, clientManager, reactor, timeoutHandler);
 	} else {
 		timeoutHandler.updateActivity(fd, status);
-		if (status == READ_COMPLETE || status == REQUEST_ERROR) {
+		if (status == WRITE_CONTINUE) {
 			reactor.addWriteEvent(fd);
 		}
 	}

--- a/src/TimeoutHandler/TimeoutHandler.cpp
+++ b/src/TimeoutHandler/TimeoutHandler.cpp
@@ -87,7 +87,6 @@ void TimeoutHandler::checkTimeouts(EventHandler& eventHandler, Demultiplexer& re
             // Request Timeout일 경우 HTTP 408 Request Timeout 처리
             eventHandler.handleError(408, *client);
             reactor.addWriteEvent(fd);
-            client->setConnectionClosed();
         } else {
             //IDLE Timeout일 경우 나머지 리소스도 정리
             clientManager.removeClient(fd);


### PR DESCRIPTION
### 문제 상황
과제 요구사항을 만족하도록 수정한 후, siege -b 테스트 시 `TIME_WAIT` 상태의 포트가 과다하게 생겨 자원 분배에 한계가 생깁니다(abort 발생). 실제로 16363개의 포트가 `TIME_WAIT` 상태에 빠짐을 확인했습니다.
아마 쓰기 작업이 다음 이벤트 루프로 지연되면서 동시에 처리되는 연결 수가 증가하고, 이에 따라 서버가 더 많은 소켓을 동시에 close()하기 때문에 
따라서 연결 종료 방식 및 이벤트 처리 로직에 대한 최적화가 필요합니다. 

### 기존 방식으로 선회
기존 로직은 요청 수신 후 바로 쓰기를 시도하는 방식이었습니다. 이 경우 siege -b 테스트 시 100% available 했습니다. 
로직 자체에는 문제가 없다고 생각했으나, 과제의 요구사항에 위배될지 모르기에 수정했습니다. 
그러나, 문제의 요구사항은 해석의 여지가 열려있고, 충분히 이 설계를 선택한 이유를 납득시킬 수 있다고 생각합니다.
다만, 과제에서 명백하게 나와있는 요구사항 중 I/O 처리는 무조건 select를 거쳐야만 수행할 수 있다는 내용이 있습니다. 
따라서 timeout시 바로 응답 전송을 시도했던 기존 방식은 수정합니다. 
이 경우 `TIME_WAIT`에 빠지는 포트 수가 3700개 정도로 유의미하게 최적화 됨을 확인했습니다.

### 변경 사항
- clientSession내에서 관리하던 conncetionClosed_ 상태 변수 및 관련 메소드 제거(불필요)
- recv후 send 시도
- try-catch문 제거(불필요)
- handleError 시 send는 하지 않음에 따른 로직 반영